### PR TITLE
Bugfix/emails

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/AccountController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/AccountController.cs
@@ -11,7 +11,6 @@ using ShareBook.Repository.Infra.CrossCutting.Identity.Configurations;
 using ShareBook.Repository.Infra.CrossCutting.Identity.Interfaces;
 using ShareBook.Service;
 using System;
-using System.Net.Http;
 using System.Threading;
 
 namespace ShareBook.Api.Controllers

--- a/ShareBook/ShareBook.Api/Controllers/CategoryController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/CategoryController.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using ShareBook.Api.ViewModels;
 using ShareBook.Domain;
 using ShareBook.Service;
 

--- a/ShareBook/ShareBook.Api/Controllers/ContactUsController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/ContactUsController.cs
@@ -1,15 +1,10 @@
 ﻿using AutoMapper;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using ShareBook.Api.Filters;
 using ShareBook.Api.ViewModels;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Service;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ShareBook.Api.Controllers
 {

--- a/ShareBook/ShareBook.Api/Controllers/Generic/BaseController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/Generic/BaseController.cs
@@ -1,6 +1,4 @@
-﻿using AutoMapper;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Cors;
+﻿using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using ShareBook.Api.Filters;
 using ShareBook.Api.ViewModels;

--- a/ShareBook/ShareBook.Api/ViewModels/BooksVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/BooksVM.cs
@@ -1,5 +1,4 @@
-﻿using ShareBook.Domain.Enums;
-using System;
+﻿using System;
 namespace ShareBook.Api.ViewModels
 {
     public class BooksVM

--- a/ShareBook/ShareBook.Api/ViewModels/ChangePasswordUserVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/ChangePasswordUserVM.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ShareBook.Api.ViewModels
+﻿namespace ShareBook.Api.ViewModels
 {
     public class ChangePasswordUserVM
     {

--- a/ShareBook/ShareBook.Api/ViewModels/ContactUsVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/ContactUsVM.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace ShareBook.Api.ViewModels
+﻿namespace ShareBook.Api.ViewModels
 {
     public class ContactUsVM
     {

--- a/ShareBook/ShareBook.Api/ViewModels/MyBooksRequestsVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/MyBooksRequestsVM.cs
@@ -1,5 +1,4 @@
-﻿using ShareBook.Domain.Enums;
-using System;
+﻿using System;
 
 namespace ShareBook.Api.ViewModels
 {

--- a/ShareBook/ShareBook.Api/ViewModels/UpdateBookVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/UpdateBookVM.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using ShareBook.Domain.Enums;
+﻿using ShareBook.Domain.Enums;
 using System;
 
 namespace ShareBook.Api.ViewModels

--- a/ShareBook/ShareBook.Api/ViewModels/UpdateUserVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/UpdateUserVM.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using ShareBook.Domain;
-using ShareBook.Domain.Enums;
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace ShareBook.Api.ViewModels

--- a/ShareBook/ShareBook.Domain/ContactUs.cs
+++ b/ShareBook/ShareBook.Domain/ContactUs.cs
@@ -1,7 +1,4 @@
 ﻿using ShareBook.Domain.Common;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ShareBook.Domain
 {

--- a/ShareBook/ShareBook.Domain/Validators/ContactUsValidator.cs
+++ b/ShareBook/ShareBook.Domain/Validators/ContactUsValidator.cs
@@ -1,5 +1,4 @@
 ﻿using FluentValidation;
-using ShareBook.Domain.Enums;
 
 namespace ShareBook.Domain.Validators
 {

--- a/ShareBook/ShareBook.Helper/Extensions/StringExtension.cs
+++ b/ShareBook/ShareBook.Helper/Extensions/StringExtension.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 

--- a/ShareBook/ShareBook.Repository/Migrations/20180719171057_AlterTables_ImageSlug.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180719171057_AlterTables_ImageSlug.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180807184445_AlterTables_AddIdBookUser.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180807184445_AlterTables_AddIdBookUser.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
 using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180808002042_AlterTables_BookSlug.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180808002042_AlterTables_BookSlug.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180808175130_AlterTables_DonationStatus.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180808175130_AlterTables_DonationStatus.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180808185930_AlterTables_NoteBookUsers.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180808185930_AlterTables_NoteBookUsers.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180829194258_AlterTable_IncreaseFields.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180829194258_AlterTable_IncreaseFields.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180905192552_IncreaseDonationNote.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180905192552_IncreaseDonationNote.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20180906200545_AlterTables_Reason.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180906200545_AlterTables_Reason.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Migrations/20181020195749_AlterTable_CreationDate.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20181020195749_AlterTable_CreationDate.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace ShareBook.Repository.Migrations
 {

--- a/ShareBook/ShareBook.Repository/Repository/Generic/IRepositoryGeneric.cs
+++ b/ShareBook/ShareBook.Repository/Repository/Generic/IRepositoryGeneric.cs
@@ -31,12 +31,12 @@ namespace ShareBook.Repository
         /// <para>Using this method will return onlye the Entity, without the children.</para>
         /// <para>If you want to get the Child Objects too, use the <seealso cref="Find(IncludeList{TEntity}, object[])"/> method.</para>
         /// </summary>
-        TEntity Find(params object[] keyValues);
+        TEntity Find(object keyValue);
 
         /// <summary>
         /// Execute a Find on the DbSet using the <paramref name="keyValues"/> and the <paramref name="includes"/>
         /// </summary>
-        TEntity Find(IncludeList<TEntity> includes, params object[] keyValues);
+        TEntity Find(IncludeList<TEntity> includes, object keyValue);
 
         /// <summary>
         /// Find in the DbSet an entity that matches the specified filter.

--- a/ShareBook/ShareBook.Repository/Repository/Generic/RepositoryGeneric.cs
+++ b/ShareBook/ShareBook.Repository/Repository/Generic/RepositoryGeneric.cs
@@ -127,9 +127,9 @@ namespace ShareBook.Repository
         #region Synchronous
         public IQueryable<TEntity> Get() => _dbSet;
 
-        public TEntity Find(params object[] keyValues) => _dbSet.Find(keyValues);
+        public TEntity Find(object keyValue) => _dbSet.Find(keyValue);
 
-        public TEntity Find(IncludeList<TEntity> includes, params object[] keyValues) => FindAsync(includes, keyValues).Result;
+        public TEntity Find(IncludeList<TEntity> includes, object keyValue) => FindAsync(includes, keyValue).Result;
 
         public TEntity Find(Expression<Func<TEntity, bool>> filter) => FindAsync(null, filter).Result;
 
@@ -143,7 +143,7 @@ namespace ShareBook.Repository
 
         public PagedList<TEntity> Get<TKey>(Expression<Func<TEntity, bool>> filter, Expression<Func<TEntity, TKey>> order)
             => Get(filter, order, null);
-        
+
         public PagedList<TEntity> Get<TKey>(Expression<Func<TEntity, bool>> filter, Expression<Func<TEntity, TKey>> order, IncludeList<TEntity> includes)
            => Get(filter, order, 1, int.MaxValue, includes);
 

--- a/ShareBook/ShareBook.Service/Book/BookService.cs
+++ b/ShareBook/ShareBook.Service/Book/BookService.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
@@ -151,7 +151,7 @@ namespace ShareBook.Service
 
                 result.Value.ImageBytes = null;
 
-                //_booksEmailService.SendEmailNewBookInserted(entity);
+                _booksEmailService.SendEmailNewBookInserted(entity);
             }
             return result;
         }

--- a/ShareBook/ShareBook.Service/Book/BookService.cs
+++ b/ShareBook/ShareBook.Service/Book/BookService.cs
@@ -1,4 +1,4 @@
-using FluentValidation;
+﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
@@ -7,8 +7,8 @@ using ShareBook.Domain.Exceptions;
 using ShareBook.Helper.Extensions;
 using ShareBook.Helper.Image;
 using ShareBook.Repository;
-using ShareBook.Repository.Repository;
 using ShareBook.Repository.Infra;
+using ShareBook.Repository.Repository;
 using ShareBook.Service.Generic;
 using ShareBook.Service.Upload;
 using System;
@@ -16,7 +16,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace ShareBook.Service
 {
@@ -124,12 +123,11 @@ namespace ShareBook.Service
             .Skip((page - 1) * items)
             .Take(items).ToList();
 
-        public override Book Find(params object[] keyValues)
+        public override Book Find(object keyValue)
         {
-            var result = _repository.Find(keyValues);
+            var result = _repository.Find(keyValue);
 
             result.ImageUrl = _uploadService.GetImageUrl(result.ImageSlug, "Books");
-
 
             return result;
         }
@@ -177,7 +175,7 @@ namespace ShareBook.Service
                 entity.ImageSlug = ImageHelper.FormatImageName(entity.ImageName, entity.Title);
                 _uploadService.UploadImage(entity.ImageBytes, entity.ImageSlug, "Books");
             }
-            
+
             result.Value = _repository.UpdateAsync(entity).Result;
             result.Value.ImageBytes = null;
 
@@ -187,7 +185,7 @@ namespace ShareBook.Service
                 entity.UserId = new Guid(Thread.CurrentPrincipal?.Identity?.Name);
                 _booksEmailService.SendEmailBookApproved(entity);
             }
-               
+
 
             return result;
         }
@@ -218,10 +216,10 @@ namespace ShareBook.Service
         }
 
         public Book BySlug(string slug)
-        { 
+        {
             var pagedBook = SearchBooks(x => (x.Slug.Contains(slug)), 1, 1);
             return pagedBook.Items.FirstOrDefault();
-        }       
+        }
 
         public bool UserRequestedBook(Guid bookId)
         {
@@ -241,8 +239,8 @@ namespace ShareBook.Service
         public IList<Book> GetUserDonations(Guid userId)
         {
             return _repository.Get(
-                    book => book.UserId == userId, 
-                    book => book.CreationDate, 
+                    book => book.UserId == userId,
+                    book => book.CreationDate,
                     new IncludeList<Book>(book => book.BookUsers)
                 ).Items;
         }

--- a/ShareBook/ShareBook.Service/Book/BooksEmailService.cs
+++ b/ShareBook/ShareBook.Service/Book/BooksEmailService.cs
@@ -36,12 +36,12 @@ namespace ShareBook.Service
             if (book.User == null)
                 book.User = _userService.Find(book.UserId);
 
-            await SendEmailNewBookInsertedToAdministrator(book);
+            await SendEmailNewBookInsertedToAdministrators(book);
 
             await SendEmailWaitingApprovalToUser(book);
         }
 
-        private async Task SendEmailNewBookInsertedToAdministrator(Book book)
+        private async Task SendEmailNewBookInsertedToAdministrators(Book book)
         {
             var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(NewBookInsertedTemplate, book);
             await _emailService.SendToAdmins(html, NewBookInsertedTitle);

--- a/ShareBook/ShareBook.Service/ContactUs/ContactUsEmailService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/ContactUsEmailService.cs
@@ -23,32 +23,19 @@ namespace ShareBook.Service
         }
         public async Task SendEmailContactUs(ContactUs contactUs)
         {
-            var administrators = _userService.GetAllAdministrators();
-
-            foreach (var admin in administrators)
-                await SendEmailContactUsToAdministrator(contactUs, admin);
+            await SendEmailContactUsToAdministrator(contactUs);
 
             await SendEmailNotificationToUser(contactUs);
         }
-        private async Task SendEmailContactUsToAdministrator(ContactUs contactUs, User administrator)
+        private async Task SendEmailContactUsToAdministrator(ContactUs contactUs)
         {
-            var vm = new
-            {
-                ContactUs = contactUs,
-                Administrator = administrator
-            };
-
-            var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(ContactUsTemplate, vm);
-            bool copyAdmins = false;
-            _emailService.Send(administrator.Email, administrator.Name, html, ContactUsTitle, copyAdmins);
+            var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(ContactUsTemplate, contactUs);
+            await _emailService.SendToAdmins(html, ContactUsTitle);
         }
         private async Task SendEmailNotificationToUser(ContactUs contactUs)
         {
-            bool copyAdmins = true;
-
             var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(ContactUsNotificationTemplate, contactUs);
-            _emailService.Send(contactUs.Email, contactUs.Name, html, ContactUsNotificationTitle, copyAdmins);
+            await _emailService.Send(contactUs.Email, contactUs.Name, html, ContactUsNotificationTitle, true);
         }
-
     }
 }

--- a/ShareBook/ShareBook.Service/ContactUs/ContactUsService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/ContactUsService.cs
@@ -1,7 +1,6 @@
 ﻿using FluentValidation;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
-using ShareBook.Service.Generic;
 
 namespace ShareBook.Service
 {

--- a/ShareBook/ShareBook.Service/Email/EmailService.cs
+++ b/ShareBook/ShareBook.Service/Email/EmailService.cs
@@ -1,7 +1,7 @@
 ﻿using MailKit.Net.Smtp;
 using Microsoft.Extensions.Options;
 using MimeKit;
-
+using System.Threading.Tasks;
 
 namespace ShareBook.Service
 {
@@ -14,7 +14,13 @@ namespace ShareBook.Service
             _settings = emailSettings.Value;
         }
 
-        public async void Send(string emailRecipient, string nameRecipient, string messageText, string subject, bool copyAdmins)
+        public async Task SendToAdmins(string messageText, string subject)
+            => await Send(_settings.Username, "Administradores Sharebook", messageText, subject, false);
+
+        public async Task Send(string emailRecipient, string nameRecipient, string messageText, string subject)
+            => await Send(emailRecipient, nameRecipient, messageText, subject, false);
+
+        public async Task Send(string emailRecipient, string nameRecipient, string messageText, string subject, bool copyAdmins)
         {
             var message = FormatEmail(emailRecipient, nameRecipient, messageText, subject, copyAdmins);
             try
@@ -30,13 +36,11 @@ namespace ShareBook.Service
                     client.Disconnect(true);
                 }
             }
-            catch (System.Exception )
+            catch (System.Exception)
             {
 
-               //v2 implementar log para exceptions
+                //v2 implementar log para exceptions
             }
-            
-
         }
 
         private MimeMessage FormatEmail(string emailRecipient, string nameRecipient, string messageText, string subject, bool copyAdmins)
@@ -45,7 +49,7 @@ namespace ShareBook.Service
             message.From.Add(new MailboxAddress("Sharebook", _settings.Username));
             message.To.Add(new MailboxAddress(nameRecipient, emailRecipient));
 
-            if(copyAdmins)
+            if (copyAdmins)
                 message.To.Add(new MailboxAddress("Sharebook", _settings.Username));
 
             message.Subject = subject;

--- a/ShareBook/ShareBook.Service/Email/IEmailService.cs
+++ b/ShareBook/ShareBook.Service/Email/IEmailService.cs
@@ -1,7 +1,11 @@
-﻿namespace ShareBook.Service
+﻿using System.Threading.Tasks;
+
+namespace ShareBook.Service
 {
     public interface IEmailService
     {
-        void Send(string emailRecipient, string nameRecipient, string messageText, string subject, bool copyAdmins);
+        Task SendToAdmins(string messageText, string subject);
+        Task Send(string emailRecipient, string nameRecipient, string messageText, string subject);
+        Task Send(string emailRecipient, string nameRecipient, string messageText, string subject, bool copyAdmins);
     }
 }

--- a/ShareBook/ShareBook.Service/Email/Templates/BookApprovedTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/BookApprovedTemplate.html
@@ -6,15 +6,15 @@
 </head>
 <body>
     <p>
-        Olá {Book.User.Name}
+        Olá {User.Name}
     </p>
     <p>
-        O livro {Book.Title} foi aprovado e já está na nossa vitrine para doação.
+        O livro {Title} foi aprovado e já está na nossa vitrine para doação.
     </p>
     <strong>Detalhes do livro: </strong>
     <ul>
-        <li><strong>Livro: </strong>{Book.Title}</li>
-        <li><strong>Autor: </strong>{Book.Author}</li>
+        <li><strong>Livro: </strong>{Title}</li>
+        <li><strong>Autor: </strong>{Author}</li>
     </ul>
 
     <p>Equipe Sharebook</p>

--- a/ShareBook/ShareBook.Service/Email/Templates/BookRequestedTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/BookRequestedTemplate.html
@@ -7,7 +7,7 @@
 <body>
     <h4>Um livro foi solicitado - Sharebook</h4>
     <p>
-        Olá {Administrator.Name},
+        Olá Administrador(a),
     </p>
     <p>
         Um livro foi solicitado. Veja mais informações abaixo:

--- a/ShareBook/ShareBook.Service/Email/Templates/ContactUsTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/ContactUsTemplate.html
@@ -171,7 +171,7 @@
                                                             width: 100%; font-size: 25px; text-align: center;
                                                             word-wrap: break-word; color: rgb(102,102,102);
                                                             cursor: text;" >
-                                                                            <span style="font-size: inherit; text-align: center; width: 100%; color: #777;">Olá, {Administrator.Name}!</span>
+                                                                            <span style="font-size: inherit; text-align: center; width: 100%; color: #777;">Olá, Administrador(a)!</span>
                                                                         </a>
                                                                     </h2>
                                                                 </td>
@@ -206,11 +206,11 @@
                                                                             <p style="text-align:left;">Um usuário entrou em contato conosco. Veja mais informações abaixo: </p>
                                                                             <br>
                                                                             <div class="float-box-footer">
-                                                                                <p style="text-align:left;">Nome: {ContactUs.Name}</p>
-                                                                                <p style="text-align:left;">Email: {ContactUs.Email}</p>
-                                                                                <p style="text-align:left;">Telefone: {ContactUs.Phone}</p>
+                                                                                <p style="text-align:left;">Nome: {Name}</p>
+                                                                                <p style="text-align:left;">Email: {Email}</p>
+                                                                                <p style="text-align:left;">Telefone: {Phone}</p>
                                                                                 <br>
-                                                                                <div style="width: 400px;"> <p style="text-align:left;">Mensagem: {ContactUs.Message}</p></div>
+                                                                                <div style="width: 400px;"> <p style="text-align:left;">Mensagem: {Message}</p></div>
                                                                             </div>
                                                                         </div>
                                                                     </div>

--- a/ShareBook/ShareBook.Service/Email/Templates/NewBookInsertedTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/NewBookInsertedTemplate.html
@@ -6,16 +6,16 @@
 </head>
 <body>
     <p>
-        Olá {Administrator.Name},
+        Olá Administrador(a),
     </p>
     <p>
         Um novo livro foi cadastrado. Veja mais informações abaixo:
     </p>
 
     <ul>
-        <li><strong>Livro: </strong>{Book.Title}</li>
-        <li><strong>Autor: </strong>{Book.Author}</li>
-        <li><strong>Usuário: </strong>{Book.User.Name}</li>
+        <li><strong>Livro: </strong>{Title}</li>
+        <li><strong>Autor: </strong>{Author}</li>
+        <li><strong>Usuário: </strong>{User.Name}</li>
     </ul>
 
     <p>Sharebook</p>

--- a/ShareBook/ShareBook.Service/Email/Templates/WaitingApprovalTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/WaitingApprovalTemplate.html
@@ -6,18 +6,18 @@
 </head>
 <body>
     <p>
-        Olá {Book.User.Name}, nossos agradecimentos por doar na plataforma Sharebook e compartilhar conhecimento!
+        Olá {User.Name}, nossos agradecimentos por doar na plataforma Sharebook e compartilhar conhecimento!
     </p>
     <p>
-        Nossa equipe já está trabalhando na aprovação do {Book.Title} e logo estará na nossa vitrine para que outras pessoas possam visualizar.
+        Nossa equipe já está trabalhando na aprovação do {Title} e logo estará na nossa vitrine para que outras pessoas possam visualizar.
     </p>
     <p>
         Solicitamos que aguarde o e-mail de confirmação dessa aprovação =)
     </p>
     <strong>Detalhes do livro: </strong>
     <ul>
-        <li><strong>Livro: </strong>{Book.Title}</li>
-        <li><strong>Autor: </strong>{Book.Author}</li>
+        <li><strong>Livro: </strong>{Title}</li>
+        <li><strong>Autor: </strong>{Author}</li>
     </ul>
 
     <p>Equipe Sharebook</p>

--- a/ShareBook/ShareBook.Service/Generic/BaseService.cs
+++ b/ShareBook/ShareBook.Service/Generic/BaseService.cs
@@ -25,10 +25,10 @@ namespace ShareBook.Service.Generic
         public bool Any(Expression<Func<TEntity, bool>> filter) => _repository.Any(filter);
         public int Count(Expression<Func<TEntity, bool>> filter) => _repository.Count(filter);
 
-        public virtual TEntity Find(params object[] keyValues)
-            => _repository.Find(keyValues);
-        public virtual TEntity Find(IncludeList<TEntity> includes, params object[] keyValues)
-            => _repository.Find(includes, keyValues);
+        public virtual TEntity Find(object keyValue)
+            => _repository.Find(keyValue);
+        public virtual TEntity Find(IncludeList<TEntity> includes, object keyValue)
+            => _repository.Find(includes, keyValue);
         public TEntity Find(Expression<Func<TEntity, bool>> filter)
             => _repository.Find(filter);
         public TEntity Find(IncludeList<TEntity> includes, Expression<Func<TEntity, bool>> filter) => _repository.Find(includes, filter);

--- a/ShareBook/ShareBook.Service/Generic/IBaseService.cs
+++ b/ShareBook/ShareBook.Service/Generic/IBaseService.cs
@@ -15,12 +15,12 @@ namespace ShareBook.Service.Generic
         /// <para>Using this method will return onlye the Entity, without the children.</para>
         /// <para>If you want to get the Child Objects too, use the <seealso cref="Find(IncludeList{TEntity}, object[])"/> method.</para>
         /// </summary>
-        TEntity Find(params object[] keyValues);
+        TEntity Find(object keyValue);
 
         /// <summary>
         /// Execute a Find on the DbSet using the <paramref name="keyValues"/> and the <paramref name="includes"/>
         /// </summary>
-        TEntity Find(IncludeList<TEntity> includes, params object[] keyValues);
+        TEntity Find(IncludeList<TEntity> includes, object keyValue);
 
         /// <summary>
         /// Find in the DbSet an entity that matches the specified filter.

--- a/ShareBook/ShareBook.Service/ShareBook.Service.csproj
+++ b/ShareBook/ShareBook.Service/ShareBook.Service.csproj
@@ -6,32 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Email\Templates\BookApprovedTemplate.html" />
-    <None Remove="Email\Templates\BookDonatedTemplate.html" />
-    <None Remove="Email\Templates\BookRequestedTemplate.html" />
-    <None Remove="Email\Templates\NewBookInsertedTemplate.html" />
-    <None Remove="Email\Templates\WaitingApprovalTemplate.html" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Email\Templates\BookDonatedTemplate.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Email\Templates\BookRequestedTemplate.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Email\Templates\BookApprovedTemplate.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Email\Templates\WaitingApprovalTemplate.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Email\Templates\NewBookInsertedTemplate.html">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="MailKit" Version="2.0.4" />
   </ItemGroup>
 
@@ -41,11 +15,26 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Email\Templates\BookApprovedTemplate.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Email\Templates\BookDonatedTemplate.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Email\Templates\BookRequestedTemplate.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Email\Templates\ContactUsNotificationTemplate.html">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Email\Templates\ContactUsTemplate.html">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Email\Templates\NewBookInsertedTemplate.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Email\Templates\WaitingApprovalTemplate.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 

--- a/ShareBook/ShareBook.Service/User/IUserService.cs
+++ b/ShareBook/ShareBook.Service/User/IUserService.cs
@@ -1,14 +1,12 @@
 ﻿using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Service.Generic;
-using System.Collections.Generic;
 
 namespace ShareBook.Service
 {
     public interface IUserService : IBaseService<User>
     {
         Result<User> AuthenticationByEmailAndPassword(User user);
-        IEnumerable<User> GetAllAdministrators();
         new Result<User> Update(User user);
         Result<User> ChangeUserPassword(User user, string oldPassword);
     }

--- a/ShareBook/ShareBook.Service/User/UserService.cs
+++ b/ShareBook/ShareBook.Service/User/UserService.cs
@@ -1,4 +1,4 @@
-using FluentValidation;
+﻿using FluentValidation;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Helper.Crypto;
@@ -90,10 +90,10 @@ namespace ShareBook.Service
             return result;
         }
 
-        public override User Find(params object[] keyValues)
+        public override User Find(object keyValue)
         {
             var includes = new IncludeList<User>(x => x.Address);
-            var user = _repository.Find(includes, keyValues);
+            var user = _repository.Find(includes, keyValue);
 
             return UserCleanup(user);
         }

--- a/ShareBook/ShareBook.Service/User/UserService.cs
+++ b/ShareBook/ShareBook.Service/User/UserService.cs
@@ -1,4 +1,4 @@
-﻿using FluentValidation;
+using FluentValidation;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Helper.Crypto;
@@ -7,7 +7,6 @@ using ShareBook.Repository.Infra;
 using ShareBook.Repository.Repository;
 using ShareBook.Service.Generic;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
@@ -97,11 +96,6 @@ namespace ShareBook.Service
             var user = _repository.Find(includes, keyValues);
 
             return UserCleanup(user);
-        }
-
-        public IEnumerable<User> GetAllAdministrators()
-        {
-            return _repository.Get(x => x.Profile == Domain.Enums.Profile.Administrator).Items;
         }
 
         public Result<User> ChangeUserPassword(User user, string newPassword)

--- a/ShareBook/ShareBook.Test.Integration/Base/IntegrationTestBase.cs
+++ b/ShareBook/ShareBook.Test.Integration/Base/IntegrationTestBase.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using ShareBook.Api;
-using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 
 namespace ShareBook.Test.Integration.Base
 {

--- a/ShareBook/ShareBook.Test.Integration/BookTests/BookControllerTest.cs
+++ b/ShareBook/ShareBook.Test.Integration/BookTests/BookControllerTest.cs
@@ -1,10 +1,4 @@
 ﻿using ShareBook.Test.Integration.Base;
-using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
 
 namespace ShareBook.Test.Integration.BookTests
 {

--- a/ShareBook/ShareBook.Test.Unit/Helpers/HelperTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Helpers/HelperTests.cs
@@ -1,8 +1,5 @@
 ﻿using ShareBook.Helper.Extensions;
 using ShareBook.Helper.Image;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace ShareBook.Test.Unit.Helpers

--- a/ShareBook/ShareBook.Test.Unit/Services/EmailTemplateTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/EmailTemplateTests.cs
@@ -70,16 +70,10 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void VerifyEmailNewBookInsertedParse()
         {
-            var vm = new
-            {
-                Book = book,
-                Administrator = administrator
-            };
-
-            var result = emailTemplate.GenerateHtmlFromTemplateAsync("NewBookInsertedTemplate", vm).Result;
+            var result = emailTemplate.GenerateHtmlFromTemplateAsync("NewBookInsertedTemplate", book).Result;
             //<!DOCTYPE html>\r\n<html lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">\r\n<head>\r\n    <meta charset=\"utf-8\" />\r\n    <title>Novo livro cadastrado - Sharebook</title>\r\n</head>\r\n<body>\r\n    <p>\r\n        Olá Cussa Mitre,\r\n    </p>\r\n    <p>\r\n        Um novo livro foi cadastrado. Veja mais informações abaixo:\r\n    </p>\r\n\r\n    <ul>\r\n        <li><strong>Livro: </strong>Lord of the Rings</li>\r\n        <li><strong>Autor: </strong>J. R. R. Tolkien</li>\r\n        <li><strong>Usuário: </strong>Rodrigo</li>\r\n    </ul>\r\n\r\n    <p>Sharebook</p>\r\n</body>\r\n</html>
 
-            Assert.Contains("Olá Cussa Mitre,", result);
+            Assert.Contains("Olá Administrador(a),", result);
             Assert.Contains("<li><strong>Livro: </strong>Lord of the Rings</li>", result);
             Assert.Contains("<li><strong>Autor: </strong>J. R. R. Tolkien</li>", result);
             Assert.Contains("<li><strong>Usuário: </strong>Rodrigo</li>", result);
@@ -98,7 +92,7 @@ namespace ShareBook.Test.Unit.Services
             var result = emailTemplate.GenerateHtmlFromTemplateAsync("BookRequestedTemplate", vm).Result;
             //<!DOCTYPE html>\r\n<html lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\">\r\n<head>\r\n    <meta charset=\"utf-8\" />\r\n    <title>Um livro foi solicitado - Sharebook</title>\r\n</head>\r\n<body>\r\n    <p>\r\n        Olá Cussa Mitre,\r\n    </p>\r\n    <p>\r\n        Um livro foi solicitado. Veja mais informações abaixo:\r\n    </p>\r\n\r\n    <ul>\r\n        <li><strong>Livro: </strong>Lord of the Rings</li>\r\n        <li><strong>Donatario: </strong>Walter Vinicius</li>\r\n        <li><strong>Linkedin Donatario:</strong>linkedin.com/walter</li>\r\n        <li><strong>Doador: </strong>Rodrigo</li>\r\n        <li><strong>Linkedin Doador:</strong>linkedin.com/rodrigo</li>\r\n    </ul>\r\n\r\n    <p>Sharebook</p>\r\n</body>\r\n</html>
 
-            Assert.Contains("Olá Cussa Mitre,", result);
+            Assert.Contains("Olá Administrador(a),", result);
             Assert.Contains("<li><strong>Livro: </strong>Lord of the Rings</li>", result);
             Assert.Contains("<li><strong>Nome: </strong>Walter Vinicius</li>", result);
             Assert.Contains("<li><strong>Linkedin: </strong>linkedin.com/walter</li>", result);
@@ -113,9 +107,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void VerifyEmailBookApprovedParse()
         {
-            var vm = new { Book = book };
-
-            var result = emailTemplate.GenerateHtmlFromTemplateAsync("BookApprovedTemplate", vm).Result;
+            var result = emailTemplate.GenerateHtmlFromTemplateAsync("BookApprovedTemplate", book).Result;
 
             Assert.Contains("<title>Livro aprovado - Sharebook</title>", result);
             Assert.Contains("Olá Rodrigo", result);
@@ -143,16 +135,9 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void VerifyEmailContactUsTemplateParse()
         {
+            var result = emailTemplate.GenerateHtmlFromTemplateAsync("ContactUsTemplate", contactUs).Result;
 
-            var vm = new
-            {
-                ContactUs = contactUs,
-                Administrator = administrator
-            };
-
-            var result = emailTemplate.GenerateHtmlFromTemplateAsync("ContactUsTemplate", vm).Result;
-
-            Assert.Contains("Olá, Cussa Mitre!", result);
+            Assert.Contains("Olá, Administrador(a)!", result);
             Assert.Contains("Nome: Rafael Rocha", result);
             Assert.Contains("Email: rafael@sharebook.com.br", result);
             Assert.Contains("Telefone: (11) 954422-2765", result);


### PR DESCRIPTION
# Erro: envio de e-mail para todos
Dado que fizemos algumas alterações nos métodos de base, não percebemos que o método que pegava os usuários administradores foi afeto. Como isso era utilizado para fazer o envio para adminstradotres e apenas ali, mudamos para enviar para a lista de admins, e nao um e-mail para cada.

## Ponto de Atenção
Eu mudei o RepositoryBase para receber agora apenas um object no método de find. O fato de termos um overload que recebia object[] estava gerando erros em alguns pontos do programa. Como não tentamos buscar mais de uma entidade pelo id, isso não gerará impactos no sistema.

### Modificações
* Ajustes do base
* Melhoria na forma de enviar emails para administradores
* Ajustes de templates e services de envio de email
* Removendo o método getAllAdministrators
* Voltando a enviar e-mail na inclusão do livro
* Ajustando overloads para método de Find
* Ajustes dos testes
* Removendo usings desnecessários