### PR TITLE
email para recuperação de senha no corpo do POST

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/AccountController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/AccountController.cs
@@ -111,12 +111,12 @@ namespace ShareBook.Api.Controllers
         }
 
 
-        [HttpPost("ForgotMyPassword/{email}")]
+        [HttpPost("ForgotMyPassword")]
         [ProducesResponseType(typeof(Result), 200)]
         [ProducesResponseType(404)]
-        public IActionResult ForgotMyPassword(string email)
+        public IActionResult ForgotMyPassword([FromBody]ForgotMyPasswordVM forgotMyPasswordVM)
         {
-            var result = _userService.GenerateHashCodePasswordAndSendEmailToUser(email);
+            var result = _userService.GenerateHashCodePasswordAndSendEmailToUser(forgotMyPasswordVM.Email);
 
             if (result.Success)
                 return Ok(result);

--- a/ShareBook/ShareBook.Api/ViewModels/ForgotMyPasswordVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/ForgotMyPasswordVM.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ShareBook.Api.ViewModels
+{
+    public class ForgotMyPasswordVM
+    {
+        [Required]
+        public string Email { get; set; }
+    }
+}


### PR DESCRIPTION
Esta mudança visa arrumar o bug #167, movendo o parâmetro de email de recuperação de senha da URL para o corpo da requisição. Dessa forma, conseguiremos incluir emails mais complexos (p. ex, com sinal "+" no endereço).