### PR TITLE
Fix #219

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/BookController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/BookController.cs
@@ -280,7 +280,6 @@ namespace ShareBook.Api.Controllers
 
         [Authorize("Bearer")]
         [HttpPut("RenewChooseDate/{bookId}")]
-        [ProducesResponseType(typeof(Result), 200)]
         public IActionResult RenewChooseDate(Guid bookId)
         {
             if (!_IsBookOwner(bookId)) return Unauthorized();

--- a/ShareBook/ShareBook.Service/User/UserService.cs
+++ b/ShareBook/ShareBook.Service/User/UserService.cs
@@ -102,9 +102,7 @@ namespace ShareBook.Service
         public override User Find(object keyValue)
         {
             var includes = new IncludeList<User>(x => x.Address);
-            var user = _repository.Find(includes, keyValue);
-
-            return UserCleanup(user);
+            return _repository.Find(includes, keyValue);
         }
 
         public Result<User> ValidOldPasswordAndChangeUserPassword(User user, string newPassword)


### PR DESCRIPTION
O UserService tem um método de find que retorna um usuário sem o campo senha. Internamente ele busca o objeto cheio e modifica o campo. Nesse momento o EF começa a RASTREAR esse objeto.

De formar que se houver uma persistência posterior, esse objeto vai junto. Mesmo que seja totalmente indesejado e inesperado, como é o motivo desse bug.

A situação é mais crítica ainda, pois leve em consideração que esse método é chamado 16 vezes em todo o sistema. Uma verdadeira BOMBA-RELÓGIO que poderia causar muitas outras perdas de senhas nos lugares mais inesperados.

Realmente a gente precisa limpar o objeto antes de mandar pro front. Eu dei uma revisada nos endpoints e vi que todos já tem VM que são responsáveis pela limpeza. E na hora e lugar certo.

