### PR TITLE
Issue #267 - Increasing Categories Search Size

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/CategoryController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/CategoryController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using ShareBook.Domain;
+using ShareBook.Domain.Common;
 using ShareBook.Service;
 
 namespace ShareBook.Api.Controllers
@@ -11,5 +12,7 @@ namespace ShareBook.Api.Controllers
         {
             SetDefault(x => x.Name);
         }
+
+        public override PagedList<Category> GetAll() => Paged(1, 50);
     }
 }


### PR DESCRIPTION
There is a need of increasing the number of categories per page. By overriding `PagedList` method on `CategoryController`, we are able to increase the number of items per page to 50, solving the issue of bringing only 15 items at a time.