### PR TITLE
Refatoração para criar um endpoint para permitir a atualização de Status do Livro

### DIFF
--- a/ShareBook/ShareBook.Service/Book/BooksEmailService.cs
+++ b/ShareBook/ShareBook.Service/Book/BooksEmailService.cs
@@ -11,6 +11,11 @@ namespace ShareBook.Service
         private const string WaitingApprovalTitle = "Aguarde aprovação do livro - Sharebook";
         private const string BookApprovedTemplate = "BookApprovedTemplate";
         private const string BookApprovedTitle = "Livro aprovado - Sharebook";
+        private const string BookSentTemplate = "BookSentTemplate";
+        private const string BookReceivedTemplate = "BookReceivedTemplate";
+        private const string BookReceivedTitle = "Livro entregue";
+        private const string BookTrackingNumberNoticeWinnerTitle = "Seu livro foi postado - Sharebook";
+
         private readonly IEmailService _emailService;
         private readonly IUserService _userService;
         private readonly IEmailTemplate _emailTemplate;
@@ -63,6 +68,36 @@ namespace ShareBook.Service
                 var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(WaitingApprovalTemplate, book);
 
                 await _emailService.Send(book.User.Email, book.User.Name, html, WaitingApprovalTitle, copyAdmins: true);
+            }
+        }
+
+        public async Task SendEmailBookSent(BookUser bookUserWinner, Book book)
+        {
+            if (bookUserWinner.User.AllowSendingEmail)
+            {
+                var vm = new
+                {
+                    book = book,
+                    NameFacilitator = book.UserFacilitator.Name,
+                    LinkedInFacilitator = book.UserFacilitator.Linkedin,
+                    ZapFacilitator = book.UserFacilitator.Phone,
+                    EmailFacilitator = book.UserFacilitator.Email,
+                };
+                var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(BookSentTemplate, vm);
+                await _emailService.Send(bookUserWinner.User.Email, bookUserWinner.User.Name, html, BookTrackingNumberNoticeWinnerTitle, copyAdmins: false);
+            }
+        }
+
+        public async Task SendEmailBookReceived(Book book)
+        {
+            if (book.User.AllowSendingEmail)
+            {
+                var vm = new
+                {
+                    book = book,
+                };
+                var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(BookReceivedTemplate, vm);
+                await _emailService.Send(book.User.Email, book.User.Name, html, BookReceivedTitle, copyAdmins: false);
             }
         }
     }

--- a/ShareBook/ShareBook.Service/Book/IBookService.cs
+++ b/ShareBook/ShareBook.Service/Book/IBookService.cs
@@ -1,5 +1,6 @@
 ﻿using ShareBook.Domain;
 using ShareBook.Domain.Common;
+using ShareBook.Domain.Enums;
 using ShareBook.Service.Generic;
 using System;
 using System.Collections.Generic;
@@ -8,9 +9,7 @@ namespace ShareBook.Service
 {
     public interface IBookService : IBaseService<Book>
     {
-        Result<Book> Approve(Guid bookId, DateTime? chooseDate);
-
-        void HideBook(Guid bookId);
+        void UpdateStatus(Guid bookId, BookStatus status, bool isAdmin);
 
         IList<dynamic> FreightOptions();
 

--- a/ShareBook/ShareBook.Service/Book/IBooksEmailService.cs
+++ b/ShareBook/ShareBook.Service/Book/IBooksEmailService.cs
@@ -9,5 +9,8 @@ namespace ShareBook.Service
 
         Task SendEmailBookApproved(Book book);
 
+        Task SendEmailBookSent(BookUser bookUserWinner, Book book);
+
+        Task SendEmailBookReceived(Book book);
     }
 }

--- a/ShareBook/ShareBook.Service/Email/Templates/BookCanceledTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/BookCanceledTemplate.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <meta charset="utf-8" />

--- a/ShareBook/ShareBook.Service/Email/Templates/BookReceivedTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/BookReceivedTemplate.html
@@ -1,0 +1,34 @@
+﻿﻿<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta charset="utf-8" />
+    <title> SHAREBOOK - Livro Entregue</title>
+</head>
+
+<body>
+
+    <p>
+        Olá,<br /><br />
+
+        Temos uma notícia boa.
+        <br /> O livro <strong>{book.Title}</strong> que você dou foi entregue com sucesso! Parabéns pela doação, ficamos muito felizes com sua boa ação!
+
+    </p>
+
+
+    <p>
+        Atenciosamente,<br /><br />
+
+        Sharebook team - Compartilhando conhecimento<br />
+        Siga-nos no instagram:
+        <a target="_blank" href="https://www.instagram.com/sharebook.com.br/" title="Instagram Sharebook">@sharebook.com.br</a>
+        <br>
+        <br>
+        Curta nossa fanpage pra ficar por dentro das novidades:<br>
+        <a href="https://www.linkedin.com/company/sharebook-br/" target="_blank">https://www.linkedin.com/company/sharebook-br/</a>
+    </p>
+
+</body>
+
+</html>

--- a/ShareBook/ShareBook.Service/Email/Templates/BookSentTemplate.html
+++ b/ShareBook/ShareBook.Service/Email/Templates/BookSentTemplate.html
@@ -1,0 +1,45 @@
+﻿﻿<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <meta charset="utf-8" />
+    <title> SHAREBOOK - Livro postado</title>
+</head>
+
+<body>
+
+    <p>
+        Olá,<br /><br />
+
+        Temos uma notícia boa.
+        <br /> O livro <strong>{book.Title}</strong> foi enviado de modo amigável, ou seja, não foi preciso enviar via Correios. Parabéns pela atitude de vocês!
+
+    </p>
+
+    <p>
+        Em caso de dúvidas ou atraso não hesite em falar com o Facilitador. Nós queremos muito que o livro
+        chegue até você o mais rápido possível.
+    </p>
+
+    <ul>
+        <li><strong>Nome do Facilitador: </strong>{NameFacilitator}</li>
+        <li><strong>LinkedIn: </strong>{LinkedInFacilitator}</li>
+        <li><strong>Whatsapp: </strong>{ZapFacilitator}</li>
+        <li><strong>Email: </strong>{EmailFacilitator}</li>
+    </ul>
+
+    <p>
+        Atenciosamente,<br /><br />
+
+        Sharebook team - Compartilhando conhecimento<br />
+        Siga-nos no instagram:
+        <a target="_blank" href="https://www.instagram.com/sharebook.com.br/" title="Instagram Sharebook">@sharebook.com.br</a>
+        <br>
+        <br>
+        Curta nossa fanpage pra ficar por dentro das novidades:<br>
+        <a href="https://www.linkedin.com/company/sharebook-br/" target="_blank">https://www.linkedin.com/company/sharebook-br/</a>
+    </p>
+
+</body>
+
+</html>

--- a/ShareBook/ShareBook.Test.Unit/Services/BookServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/BookServiceTests.cs
@@ -24,6 +24,7 @@ namespace ShareBook.Test.Unit.Services
         readonly Mock<IBooksEmailService> bookEmailService;
         readonly Mock<IUnitOfWork> unitOfWorkMock;
         readonly Mock<IBookUserService> bookUserServiceMock;
+        readonly Mock<IServiceProvider> serviceProvider;
 
         public BookServiceTests()
         {
@@ -34,6 +35,7 @@ namespace ShareBook.Test.Unit.Services
             bookRepositoryMock = new Mock<IBookRepository>();
             bookEmailService = new Mock<IBooksEmailService>();
             bookUserServiceMock = new Mock<IBookUserService>();
+            serviceProvider = new Mock<IServiceProvider>();
 
             bookRepositoryMock.Setup(repo => repo.Insert(It.IsAny<Book>())).Returns(() =>
             {
@@ -51,7 +53,7 @@ namespace ShareBook.Test.Unit.Services
             Thread.CurrentPrincipal = new UserMock().GetClaimsUser();
             var service = new BookService(bookRepositoryMock.Object, 
                 unitOfWorkMock.Object, new BookValidator(),
-                uploadServiceMock.Object, bookEmailService.Object);
+                uploadServiceMock.Object, bookEmailService.Object, serviceProvider.Object);
             Result<Book> result = service.Insert(new Book()
             {
                 Title = "Lord of the Rings",


### PR DESCRIPTION
Tarefa: https://trello.com/c/ZJxwDule/164-416-informar-o-recebimento-de-livro

Descrição: Para efetuar a refatoração para permitir que um usuário possa informar o recebimento de um livro, foi decido, através de reunião com o @raffacabofrio , que seria mais interessante criar um único endpoint para evitar segmentação de endpoints para atualizar o Status de um livro. Dessa forma, essa refatoração permite a atualização de Status que um usuário (Admin ou outros) teria permissão, alguns Status não são permitidos, visto que eles já são atribuídos automaticamente de acordo com a regra de negócio do projeto. 
Além disso, também implementei mais dois métodos para envio de e-mail, os quais são referentes aos Status "Sent" e "Received".