### PR TITLE
Add unique email index.

### DIFF
--- a/ShareBook/ShareBook.Repository/Mapping/UserMap.cs
+++ b/ShareBook/ShareBook.Repository/Mapping/UserMap.cs
@@ -21,6 +21,9 @@ namespace ShareBook.Repository.Mapping
                 .HasMaxLength(100)
                 .IsRequired();
 
+            entityBuilder.HasIndex(t => t.Email)
+                .IsUnique();
+
             entityBuilder.Property(t => t.Password)
                     .HasColumnType("varchar(50)")
                     .HasMaxLength(50)

--- a/ShareBook/ShareBook.Repository/Migrations/20200912230347_IndexUniqueEmail.Designer.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20200912230347_IndexUniqueEmail.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ShareBook.Repository;
 
 namespace ShareBook.Repository.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200912230347_IndexUniqueEmail")]
+    partial class IndexUniqueEmail
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ShareBook/ShareBook.Repository/Migrations/20200912230347_IndexUniqueEmail.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20200912230347_IndexUniqueEmail.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ShareBook.Repository.Migrations
+{
+    public partial class IndexUniqueEmail : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_Email",
+                table: "Users",
+                column: "Email",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Users_Email",
+                table: "Users");
+        }
+    }
+}


### PR DESCRIPTION
Um usuário reclamou que não estava conseguindo entrar e nem recuperar senha no Sharebook.

Após investigar reparei que o email dele estava duplicado no banco de dados. O que é bem estranho porque a gente trata isso no backend.

Além desse usuário haviam outros 11 usuários com o mesmo problema.

Eu suspeito que esse problema esteja relacionado com alguma indisponibilidade temporária do banco de dados. E alguma lógica de retry no EF. Porque em todos os casos as datas de criação eram iguais.

AÇÃO CORRETIVA
- Excluir manualmente os registros duplicados. *OK*
- Criar um índice unique no campo email. ( Essa PR )