### PR TITLE
Avaliar resultado antes de retornar ação create/update

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/BookController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/BookController.cs
@@ -234,7 +234,11 @@ namespace ShareBook.Api.Controllers
         public IActionResult Create([FromBody] CreateBookVM createBookVM)
         {
             var book = _mapper.Map<Book>(createBookVM);
-            _service.Insert(book);
+            var result = _service.Insert(book);
+            if (!result.Success)
+            {
+                return BadRequest(result);
+            }
             return Ok(new Result { SuccessMessage = "Livro cadastrado com sucesso! Aguarde aprovação." });
         }
 
@@ -245,7 +249,11 @@ namespace ShareBook.Api.Controllers
         {
             updateBookVM.Id = Id;
             var book = _mapper.Map<Book>(updateBookVM);
-            _service.Update(book);
+            var result = _service.Update(book);
+            if (!result.Success)
+            {
+                return BadRequest(result);
+            }
             return Ok(new Result { SuccessMessage = "Livro alterado com sucesso!" });
         }
 


### PR DESCRIPTION
Ao tentar cadastrar um livro, não há verificação se a operação ocorreu como deveria, sempre retornando 200 e mensagem de sucesso.
Este pull request adiciona a verificação da propriedade ```Result.IsSuccess``` gerado pelo serviço, para que retorne 400 com a mensagem de erro quando necessário.

Exemplo de um POST de um livro inválido que retorna 200 mas não é cadastrado pois falha na validação de formato de imagem:
> {
>   "title": "Um livro aleatório",
>   "author": "Um autor desconhecido",
>   "categoryId": "B1A34609-A85C-4B36-893F-BA56AE911C2D",
>   "imageName": "string",
>   "imageBytes": "00000000",
>   "freightOption": "0",
>   "synopsis": "string",
>   "type": "1",
>   "eBookDownloadLink": "",
>   "eBookPdfFile": ""
> }