### PR TITLE
Checar se há imagem com o mesmo nome antes do upload

### DIFF
--- a/ShareBook/ShareBook.Service/Upload/UploadService.cs
+++ b/ShareBook/ShareBook.Service/Upload/UploadService.cs
@@ -29,6 +29,16 @@ namespace ShareBook.Service.Upload
         {
             var dinamicDirectory = Path.Combine(_imageSettings.ImagePath, lastDirectory);
 
+            var directoryBase = AppDomain.CurrentDomain.BaseDirectory + dinamicDirectory;
+
+            var testPath = Path.Combine(directoryBase, imageName);
+
+            if (File.Exists(testPath))
+            {
+                var extension = Path.GetExtension(imageName);
+                imageName = Path.GetFileNameWithoutExtension(testPath) + DateTimeOffset.Now.ToUnixTimeSeconds() + extension;
+            }
+
             UploadFile(imageBytes, imageName, dinamicDirectory);
 
             return GetImageUrl(imageName, lastDirectory);


### PR DESCRIPTION
Checa se há outra imagem com o mesmo nome ao realizar upload, caso positivo adicionar data no formato Unix ao final do nome do arquivo.