### PR TITLE
Adicionar campo Instagram para usuário.

### DIFF
--- a/ShareBook/ShareBook.Api/ViewModels/UpdateUserVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/UpdateUserVM.cs
@@ -13,6 +13,8 @@ namespace ShareBook.Api.ViewModels
         public string Email { get; set; }
 
         public string Linkedin { get; set; }
+        
+        public string Instagram { get; set; }
 
         public Address Address { get; set; }
 

--- a/ShareBook/ShareBook.Api/ViewModels/UserVM.cs
+++ b/ShareBook/ShareBook.Api/ViewModels/UserVM.cs
@@ -12,6 +12,8 @@ namespace ShareBook.Api.ViewModels
 
         public string Linkedin { get; set; }
 
+        public string Instagram { get; set; }
+
         public string Phone { get; set; }
 
         public Address Address { get; set; }
@@ -29,6 +31,8 @@ namespace ShareBook.Api.ViewModels
         public string Email { get; set; }
 
         public string Linkedin { get; set; }
+
+        public string Instagram { get; set; }
 
         public string Phone { get; set; }
 

--- a/ShareBook/ShareBook.Domain/DTOs/RegisterUserDTO.cs
+++ b/ShareBook/ShareBook.Domain/DTOs/RegisterUserDTO.cs
@@ -24,6 +24,8 @@ namespace ShareBook.Domain.DTOs
         public string Country { get; set; }
 
         public string Linkedin { get; set; }
+        
+        public string Instagram { get; set; }
 
         public string Phone { get; set; }
 

--- a/ShareBook/ShareBook.Domain/User.cs
+++ b/ShareBook/ShareBook.Domain/User.cs
@@ -18,6 +18,7 @@ namespace ShareBook.Domain
         public DateTime HashCodePasswordExpiryDate { get; set; }
         public DateTime LastLogin { get; set; } = DateTime.Now;
         public string Linkedin { get; set; }
+        public string Instagram { get; set; }
         public  string Phone{ get; set; }
         public Profile Profile { get;  set; } = Profile.User;
         public bool Active { get; set; } = true;
@@ -58,11 +59,12 @@ namespace ShareBook.Domain
                 && (this.HashCodePasswordExpiryDate.Date == DateTime.Now.AddDays(1).Date
                    || this.HashCodePasswordExpiryDate.Date == DateTime.Now.Date);
 
-        public void Change(string email, string name, string linkedin, string phone, bool AllowSendingEmail)
+        public void Change(string email, string name, string linkedin, string instagram, string phone, bool AllowSendingEmail)
         {
             this.Email = email;
             this.Name = name;
             this.Linkedin = linkedin;
+            this.Instagram = instagram;
             this.Phone = phone;
             this.AllowSendingEmail = AllowSendingEmail;
         }
@@ -107,6 +109,7 @@ namespace ShareBook.Domain
             Active = false;
             AllowSendingEmail = false;
             Linkedin = null;
+            Instagram = null;
             Phone = null;
             ParentEmail = null;
 

--- a/ShareBook/ShareBook.Domain/Validators/UserValidator.cs
+++ b/ShareBook/ShareBook.Domain/Validators/UserValidator.cs
@@ -41,6 +41,10 @@ namespace ShareBook.Domain.Validators
                 .Must(x => OptionalFieldIsValid(x))
                 .WithMessage("Linkedln deve ter no máximo 100 caracteres");
 
+            RuleFor(u => u.Instagram)
+                .Must(x => OptionalFieldIsValid(x))
+                .WithMessage("Instagram deve ter no máximo 100 caracteres");
+
             RuleFor(u => u.Phone)
                 .NotNull()
                 .WithMessage("Telefone é obrigatório")

--- a/ShareBook/ShareBook.Repository/Mapping/UserMap.cs
+++ b/ShareBook/ShareBook.Repository/Mapping/UserMap.cs
@@ -37,6 +37,10 @@ namespace ShareBook.Repository.Mapping
                 .HasColumnType("varchar(100)")
                 .HasMaxLength(100);
 
+            entityBuilder.Property(t => t.Instagram)
+                .HasColumnType("varchar(100)")
+                .HasMaxLength(100);
+
             entityBuilder.Property(t => t.Phone)
                 .HasColumnType("varchar(30)")
                 .HasMaxLength(30);

--- a/ShareBook/ShareBook.Repository/Migrations/20220923153450_Add_Instagram_Property.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20220923153450_Add_Instagram_Property.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ShareBook.Repository.Migrations
+{
+    public partial class Add_Instagram_Property : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Instagram",
+                table: "Users",
+                type: "varchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Instagram",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Repository/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -365,6 +365,10 @@ namespace ShareBook.Repository.Migrations
                     b.Property<DateTime>("HashCodePasswordExpiryDate")
                         .HasColumnType("datetime2(7)");
 
+                    b.Property<string>("Instagram")
+                        .HasMaxLength(100)
+                        .HasColumnType("varchar(100)");
+
                     b.Property<DateTime>("LastLogin")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")

--- a/ShareBook/ShareBook.Service/User/UserService.cs
+++ b/ShareBook/ShareBook.Service/User/UserService.cs
@@ -144,7 +144,7 @@ namespace ShareBook.Service
 
             if (result.Success)
             {
-                userAux.Change(user.Email, user.Name, user.Linkedin, user.Phone, user.AllowSendingEmail);
+                userAux.Change(user.Email, user.Name, user.Linkedin, user.Instagram, user.Phone, user.AllowSendingEmail);
                 userAux.ChangeAddress(user.Address);
 
                 result.Value = UserCleanup(_repository.Update(userAux));

--- a/ShareBook/ShareBook.Test.Unit/Mocks/UserMock.cs
+++ b/ShareBook/ShareBook.Test.Unit/Mocks/UserMock.cs
@@ -37,6 +37,7 @@ namespace ShareBook.Test.Unit.Mocks
                 PasswordSalt = PASSWORD_SALT,
                 Email = "rodrigo@sharebook.com",
                 Linkedin = "linkedin.com/rodrigo",
+                Instagram = "instagram.com/test/",
                 Profile = Profile.User,
                 LastLogin = DateTime.Now.AddMinutes(-60)
             };
@@ -53,6 +54,7 @@ namespace ShareBook.Test.Unit.Mocks
                 PasswordSalt = PASSWORD_SALT,
                 Email = "walter@sharebook.com",
                 Linkedin = "linkedin.com/walter",
+                Instagram = "instagram.com/test/",
                 Profile = Profile.User,
                 LastLogin = DateTime.Now.AddMinutes(-60),
                 Address = new Address()


### PR DESCRIPTION
1 - Adicionar propriedade Instagram no modelo User.cs;

2 - Referenciar a propriedade Instagram nos metodos Change(assinatura e corpo) e Anonymize(corpo) nas regras do modelo User.cs;

3 - Adicionar propriedade no DTO de User(RegisterUserDTO.cs);

4 - Adicionar regra de validacao de quantidade maxima de 100 caracteres para a propriedade Instagram no UserValidator.cs;

5 - Adicionar propriedade Instagram na chamada do metodo Change em UserService.cs

6 - Adicionar a propriedade Instagram do User no UserMap;

7 - Adicionar a propriedade Instagram no UserVM;

8 - Adicionar a propriedade Instagram no Context;

9 - Aterar o o mock de usuario adicionando o novo campo Instagram;

10 - Criar migration contendo o novo campo;