### PR TITLE
Add simple validation of recaptcha in register endpoint

### DIFF
--- a/ShareBook/ShareBook.Api/Configuration/ServiceRepositoryCollectionExtensions.cs
+++ b/ShareBook/ShareBook.Api/Configuration/ServiceRepositoryCollectionExtensions.cs
@@ -12,6 +12,7 @@ using ShareBook.Service.AWSSQS;
 using ShareBook.Service.Lgpd;
 using ShareBook.Service.Muambator;
 using ShareBook.Service.Notification;
+using ShareBook.Service.Recaptcha;
 using ShareBook.Service.Upload;
 
 namespace ShareBook.Api.Configuration
@@ -36,6 +37,7 @@ namespace ShareBook.Api.Configuration
             services.AddScoped<IAccessHistoryService, AccessHistoryService>();
             services.AddScoped<ILgpdService, LgpdService>();
             services.AddScoped<IMeetupService, MeetupService>();
+            services.AddScoped<IRecaptchaService, RecaptchaService>();
 
             //repositories
             services.AddScoped<IBookRepository, BookRepository>();

--- a/ShareBook/ShareBook.Api/Controllers/ContactUsController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/ContactUsController.cs
@@ -27,7 +27,7 @@ namespace ShareBook.Api.Controllers
         {
             var contactUS = _mapper.Map<ContactUs>(contactUsVM);
 
-            return _contactUsService.SendContactUs(contactUS);
+            return _contactUsService.SendContactUs(contactUS, contactUsVM?.RecaptchaReactive);
         }
     }
 }

--- a/ShareBook/ShareBook.Domain/Common/Result.cs
+++ b/ShareBook/ShareBook.Domain/Common/Result.cs
@@ -24,7 +24,7 @@ namespace ShareBook.Domain.Common
         }
 
         public T Value { get; set; }
-        public IList<string> Messages { get; }
+        public List<string> Messages { get; }
         public string SuccessMessage { get; set; }
 
         public bool Success { get { return Messages.Count == 0; } }

--- a/ShareBook/ShareBook.Domain/ContactUs.cs
+++ b/ShareBook/ShareBook.Domain/ContactUs.cs
@@ -8,6 +8,5 @@ namespace ShareBook.Domain
         public string Email { get; set; }
         public string Phone { get; set; }
         public string Message { get; set; }
-        public string RecaptchaReactive { get; set; }
     }
 }

--- a/ShareBook/ShareBook.Domain/DTOs/RegisterUserDTO.cs
+++ b/ShareBook/ShareBook.Domain/DTOs/RegisterUserDTO.cs
@@ -36,5 +36,6 @@ namespace ShareBook.Domain.DTOs
         public int Age { get; set; }
 
         public string ParentEmail { get; set; }
+        public string RecaptchaReactive { get; set; }
     }
 }

--- a/ShareBook/ShareBook.Domain/Validators/ContactUsValidator.cs
+++ b/ShareBook/ShareBook.Domain/Validators/ContactUsValidator.cs
@@ -10,8 +10,6 @@ namespace ShareBook.Domain.Validators
         public const string EMAIL_FORMAT = "O formato do email está inválido";
         public const string PHONE_REQUIRED = "Telefone é obrigatório";
         public const string MESSAGE_REQUIRED = "Mensagem é obrigatória";
-        public const string RECAPTCHA_REQUIRED = "RecaptchaReactive é obrigatório";
-        public const string RECAPTCHA_FORMAT = "RecaptchaReactive está inválido";
         #endregion
 
         public ContactUsValidator()
@@ -33,14 +31,6 @@ namespace ShareBook.Domain.Validators
             RuleFor(c => c.Message)
                 .NotEmpty()
                 .WithMessage(MESSAGE_REQUIRED);
-
-            RuleFor(c => c.RecaptchaReactive)
-                .NotNull()
-                .WithMessage(RECAPTCHA_REQUIRED)
-                .NotEmpty()
-                .WithMessage(RECAPTCHA_REQUIRED)
-                .MinimumLength(100)
-                .WithMessage(RECAPTCHA_FORMAT);
         }
     }
 }

--- a/ShareBook/ShareBook.Service/ContactUs/ContactUsService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/ContactUsService.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
+using ShareBook.Service.Recaptcha;
 
 namespace ShareBook.Service
 {
@@ -8,16 +9,21 @@ namespace ShareBook.Service
     {
         IContactUsEmailService _contactUsEmailService;
         IValidator<ContactUs> _validator;
-        public ContactUsService(IContactUsEmailService contactUsEmailService, IValidator<ContactUs> validator)
+        IRecaptchaService _recaptchaService;
+        public ContactUsService(IContactUsEmailService contactUsEmailService, IValidator<ContactUs> validator, IRecaptchaService recaptchaService)
         {
             _contactUsEmailService = contactUsEmailService;
             _validator = validator;
+            _recaptchaService = recaptchaService;
         }
-        public Result<ContactUs> SendContactUs(ContactUs entity)
+        public Result<ContactUs> SendContactUs(ContactUs entity, string recaptchaReactive)
         {
 
             var result = new Result<ContactUs>(_validator.Validate(entity));
-            // TODO: Fazer a validação real do "RecaptchaReactive" (https://developers.google.com/recaptcha/docs/verify)
+
+            Result resultRecaptcha = _recaptchaService.SimpleValidationRecaptcha(recaptchaReactive);
+            if (!resultRecaptcha.Success)
+                result.Messages.AddRange(resultRecaptcha.Messages);
 
             if (!result.Success)
                 return result;

--- a/ShareBook/ShareBook.Service/ContactUs/IContactUsService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/IContactUsService.cs
@@ -5,6 +5,6 @@ namespace ShareBook.Service
 {
     public interface IContactUsService
     {
-        Result<ContactUs> SendContactUs(ContactUs contactUs);
+        Result<ContactUs> SendContactUs(ContactUs contactUs, string recaptchaReactive);
     }
 }

--- a/ShareBook/ShareBook.Service/Recaptcha/IRecaptchaService.cs
+++ b/ShareBook/ShareBook.Service/Recaptcha/IRecaptchaService.cs
@@ -1,0 +1,9 @@
+﻿using ShareBook.Domain.Common;
+
+namespace ShareBook.Service.Recaptcha
+{
+    public interface IRecaptchaService
+    {
+        Result SimpleValidationRecaptcha(string recaptcha);
+    }
+}

--- a/ShareBook/ShareBook.Service/Recaptcha/RecaptchaService.cs
+++ b/ShareBook/ShareBook.Service/Recaptcha/RecaptchaService.cs
@@ -1,0 +1,17 @@
+﻿using ShareBook.Domain.Common;
+
+namespace ShareBook.Service.Recaptcha
+{
+    public class RecaptchaService : IRecaptchaService
+    {
+        // TODO: Fazer a validação real do "RecaptchaReactive" (https://developers.google.com/recaptcha/docs/verify)
+        public Result SimpleValidationRecaptcha(string recaptchaReactive)
+        {
+            Result result = new Result();
+            if (string.IsNullOrWhiteSpace(recaptchaReactive) || recaptchaReactive.Length <= 100)
+                result.Messages.Add("RecaptchaReactive está inválido!");
+
+            return result;
+        }
+    }
+}

--- a/ShareBook/ShareBook.Test.Unit/Services/ContactUsServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/ContactUsServiceTests.cs
@@ -1,0 +1,68 @@
+﻿using Moq;
+using ShareBook.Domain;
+using ShareBook.Domain.Common;
+using ShareBook.Domain.Validators;
+using ShareBook.Service;
+using ShareBook.Service.Recaptcha;
+using Xunit;
+
+namespace ShareBook.Test.Unit.Services
+{
+    public class ContactUsServiceTests
+    {
+        readonly Mock<IContactUsService> contactUsServiceMock;
+        readonly Mock<IRecaptchaService> recaptchaServiceMock;
+        readonly IRecaptchaService recaptchaService;
+        readonly Mock<IContactUsEmailService> contactUsEmailServiceMock;
+
+        public ContactUsServiceTests()
+        {
+            contactUsServiceMock = new Mock<IContactUsService>();
+            recaptchaServiceMock = new Mock<IRecaptchaService>();
+            recaptchaService = new RecaptchaService();
+            contactUsEmailServiceMock = new Mock<IContactUsEmailService>();
+
+        }
+        [Fact]
+        public void Invalid()
+        {
+            ContactUsService service = new ContactUsService(contactUsEmailServiceMock.Object, new ContactUsValidator(), recaptchaService);
+            Result<ContactUs> result = service.SendContactUs(new ContactUs
+            {
+                Email = "joazinho",
+                Message = "Test message test, Test message test, Test message test",
+                Name = "Joãozinho",
+                Phone = "44 9 8877-6655"
+            }, "kasdhauiskhduiasydyaushdausytdsuadgausydhasdg7qwqgdqdgyuqwgdusyadgh7asiyda7sdtgadgashd");
+            Assert.False(result.Success);
+        }
+
+        [Fact]
+        public void Valid()
+        {
+            ContactUsService service = new ContactUsService(contactUsEmailServiceMock.Object, new ContactUsValidator(), recaptchaService);
+            Result<ContactUs> result = service.SendContactUs(new ContactUs
+            {
+                Email = "joazinho.souza@example.com",
+                Message = "Test message test, Test message test, Test message test",
+                Name = "Joãozinho",
+                Phone = "44 9 8877-6655"
+            }, "12asdx5482asd56asd878as67d8kasdhauiskhduiasyd12a345asdaduhu12yaushdausytdsuadgausydhasdg7qwqgdqdgyuqwgdusyadgh7asiyda7sdtgadgashd");
+            Assert.True(result.Success);
+        }
+
+        [Fact]
+        public void InvalidRecaptcha()
+        {
+            ContactUsService service = new ContactUsService(contactUsEmailServiceMock.Object, new ContactUsValidator(), recaptchaService);
+            Result<ContactUs> result = service.SendContactUs(new ContactUs
+            {
+                Email = "joazinho.souza@example.com",
+                Message = "Test message test, Test message test, Test message test",
+                Name = "Joãozinho",
+                Phone = "44 9 8877-6655"
+            }, "");
+            Assert.False(result.Success);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Test.Unit/Services/RecaptchaServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/RecaptchaServiceTests.cs
@@ -1,0 +1,29 @@
+﻿using ShareBook.Domain.Common;
+using ShareBook.Service.Recaptcha;
+using Xunit;
+
+namespace ShareBook.Test.Unit.Services
+{
+    public class RecaptchaServiceTests
+    {
+        private readonly IRecaptchaService _recaptchaService = new RecaptchaService();
+        private const string validRecaptcha = "asdaasdjasodaj7i364yubki23y728374234b2jk34h2347i26348724yh2bjhk34g2j34t273842384iuh2h4j234g2j34t27834bjh";
+        private const string invalidRecaptcha = "123456";
+        public RecaptchaServiceTests() { }
+
+
+        [Fact]
+        public void ValidRecaptcha()
+        {
+            Result result = _recaptchaService.SimpleValidationRecaptcha(validRecaptcha);
+            Assert.True(result.Success);
+        }
+
+        [Fact]
+        public void InvalidRecaptcha()
+        {
+            Result result = _recaptchaService.SimpleValidationRecaptcha(invalidRecaptcha);
+            Assert.False(result.Success);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Test.Unit/Services/UserServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/UserServiceTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using ShareBook.Repository.UoW;
 using ShareBook.Infra.CrossCutting.Identity.Interfaces;
 using AutoMapper;
+using ShareBook.Service.Recaptcha;
 
 namespace ShareBook.Test.Unit.Services
 {
@@ -27,6 +28,7 @@ namespace ShareBook.Test.Unit.Services
         readonly Mock<IUnitOfWork> unitOfWorkMock;
         readonly Mock<IUserEmailService> userEmailServiceMock;
         readonly Mock<IMapper> mapperMock;
+        readonly Mock<IRecaptchaService> recaptchaServiceMock;
 
         public UserServiceTests()
         {
@@ -38,6 +40,7 @@ namespace ShareBook.Test.Unit.Services
             bookRepositoryMock = new Mock<IBookRepository>();
             userEmailServiceMock = new Mock<IUserEmailService>();
             mapperMock = new Mock<IMapper>();
+            recaptchaServiceMock = new Mock<IRecaptchaService>();
 
             //Simula login do usuario
             Thread.CurrentPrincipal = new UserMock().GetClaimsUser();
@@ -78,7 +81,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void RegisterValidUser()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
 
             Result<User> result = service.Insert(new User()
             {
@@ -96,7 +99,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void RegisterInvalidUser()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
 
             Result<User> result = service.Insert(new User()
             {
@@ -113,7 +116,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void UpdateValidUser()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
 
             Result<User> result = service.Update(new User()
             {
@@ -141,7 +144,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void UpdateInvalidUser()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
 
             Result<User> result = service.Update(new User()
             {
@@ -158,7 +161,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void UpdateUserNotExists()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
 
             Result<User> result = service.Update(new User()
             {
@@ -176,7 +179,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void LoginValidUser()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
             Result<User> result = service.AuthenticationByEmailAndPassword(new User()
             {
                 Email = "walter@sharebook.com",
@@ -192,7 +195,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void LoginInvalidPassword()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
             Result<User> result = service.AuthenticationByEmailAndPassword(new User()
             {
                 Email = "walter@sharebook.com",
@@ -205,7 +208,7 @@ namespace ShareBook.Test.Unit.Services
         [Fact]
         public void LoginInvalidEmail()
         {
-            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object);
+            var service = new UserService(userRepositoryMock.Object, bookRepositoryMock.Object, unitOfWorkMock.Object, new UserValidator(), mapperMock.Object, userEmailServiceMock.Object, recaptchaServiceMock.Object);
             Result<User> result = service.AuthenticationByEmailAndPassword(new User()
             {
                 Email = "joao@sharebook.com",

--- a/ShareBook/ShareBook.Test.Unit/Validators/ContactUsValidatorTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Validators/ContactUsValidatorTests.cs
@@ -23,7 +23,6 @@ namespace ShareBook.Test.Unit.Validators
                 Message = "Essa mensagem é obrigatória",
                 Name = "Joao",
                 Phone = "4499988-7766",
-                RecaptchaReactive = "asdaasdjasodaj7i364yubki23y728374234b2jk34h2347i26348724yh2bjhk34g2j34t273842384iuh2h4j234g2j34t27834bjh",
             };
             ValidationResult result = contactUsValidator.Validate(contactUs);
             Assert.True(result.IsValid);
@@ -38,23 +37,6 @@ namespace ShareBook.Test.Unit.Validators
                 Message = "Essa mensagem é obrigatória",
                 Name = "Joao",
                 Phone = "4499988-7766",
-                RecaptchaReactive = "asdaasdjasodaj7i364yubki23y728374234b2jk34h2347i26348724yh2bjhk34g2j34t273842384iuh2h4j234g2j34t27834bjh",
-            };
-
-            ValidationResult result = contactUsValidator.Validate(contactUs);
-            Assert.False(result.IsValid);
-        }
-
-        [Fact]
-        public void InvalidRecaptcha()
-        {
-            ContactUs contactUs = new ContactUs
-            {
-                Email = "joao@sharebook.com.br",
-                Message = "Essa mensagem é obrigatória",
-                Name = "Joao",
-                Phone = "4499988-7766",
-                RecaptchaReactive = "",
             };
 
             ValidationResult result = contactUsValidator.Validate(contactUs);


### PR DESCRIPTION
feat: Creating IRecaptchaService + implementing simple validation of recaptcha to register, and update validation of recaptcha in contactUs (moving from FluentValidation to IRecaptchaService) + Unit tests.

Note: This will impact the validation on `ContactUs` endpoint.

Note: Depends => https://github.com/SharebookBR/sharebook-frontend/pull/438