### PR TITLE
Add busca de meetup pela descrição

### DIFF
--- a/ShareBook/ShareBook.Service/Meetup/MeetupService.cs
+++ b/ShareBook/ShareBook.Service/Meetup/MeetupService.cs
@@ -177,7 +177,7 @@ namespace ShareBook.Service
         public IList<Meetup> Search(string criteria)
         {
             return _repository.Get()
-                .Where(m => m.Title.ToUpper().Contains(criteria.ToUpper()))
+                .Where(m => m.Title.ToUpper().Contains(criteria.ToUpper()) || m.Description.ToUpper().Contains(criteria.ToUpper()))
                 .OrderByDescending(m => m.CreationDate)
                 .ToList();
         }


### PR DESCRIPTION
Adiciona possibilidade de pesquisar por termos usados na descrição, como por exemplo pelo nome dos palestrantes.