### PR TITLE
Turning endpoints of `ContactUsController` and `MeetupController` as async

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/ContactUsController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/ContactUsController.cs
@@ -5,6 +5,7 @@ using ShareBook.Api.ViewModels;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Service;
+using System.Threading.Tasks;
 
 namespace ShareBook.Api.Controllers
 {
@@ -23,11 +24,11 @@ namespace ShareBook.Api.Controllers
         }
 
         [HttpPost("SendMessage")]
-        public Result<ContactUs> SendMessage([FromBody]ContactUsVM contactUsVM)
+        public async Task<Result<ContactUs>> SendMessageAsync([FromBody]ContactUsVM contactUsVM)
         {
             var contactUS = _mapper.Map<ContactUs>(contactUsVM);
 
-            return _contactUsService.SendContactUs(contactUS, contactUsVM?.RecaptchaReactive);
+            return await _contactUsService.SendContactUsAsync(contactUS, contactUsVM?.RecaptchaReactive);
         }
     }
 }

--- a/ShareBook/ShareBook.Api/Controllers/MeetupController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/MeetupController.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Configuration;
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Service;

--- a/ShareBook/ShareBook.Api/Controllers/MeetupController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/MeetupController.cs
@@ -6,6 +6,7 @@ using ShareBook.Domain.Common;
 using ShareBook.Service;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace ShareBook.Api.Controllers
 {
@@ -37,9 +38,9 @@ namespace ShareBook.Api.Controllers
         }
 
         [HttpGet("Search")]
-        public IList<Meetup> Search([FromQuery]string criteria)
+        public async Task<IList<Meetup>> SearchAsync([FromQuery]string criteria)
         {
-            return _meetupService.Search(criteria);
+            return await _meetupService.SearchAsync(criteria);
         }
     }
 }

--- a/ShareBook/ShareBook.Api/Controllers/OperationsController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/OperationsController.cs
@@ -78,12 +78,12 @@ namespace ShareBook.Api.Controllers
         [HttpPost("EmailTest")]
         [Authorize("Bearer")]
         [AuthorizationFilter(Permissions.Permission.ApproveBook)] // adm
-        public IActionResult EmailTest([FromBody] EmailTestVM emailVM)
+        public async Task<IActionResult> EmailTestAsync([FromBody] EmailTestVM emailVM)
         {
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            _emailService.Test(emailVM.Email, emailVM.Name).Wait();
+            await _emailService.Test(emailVM.Email, emailVM.Name);
             return Ok();
         }
 

--- a/ShareBook/ShareBook.Service/Book/BookService.cs
+++ b/ShareBook/ShareBook.Service/Book/BookService.cs
@@ -185,6 +185,7 @@ namespace ShareBook.Service
 
         public override Result<Book> Insert(Book entity)
         {
+            // TODO: Migrate to Async and remove ".GetAwaiter().GetResult()" and ".Wait()"
             entity.UserId = new Guid(Thread.CurrentPrincipal?.Identity?.Name);
 
             EBookValidate(entity);
@@ -197,11 +198,11 @@ namespace ShareBook.Service
                 entity.ImageSlug = ImageHelper.FormatImageName(entity.ImageName, entity.Slug);
 
                 if (entity.IsEbookPdfValid())
-                    entity.EBookPdfFile = _uploadService.UploadPdf(entity.EBookPdfBytes, entity.EBookPdfFile, "EBooks");
+                    entity.EBookPdfFile = _uploadService.UploadPdfAsync(entity.EBookPdfBytes, entity.EBookPdfFile, "EBooks").GetAwaiter().GetResult();
 
                 result.Value = _repository.Insert(entity);
 
-                result.Value.ImageUrl = _uploadService.UploadImage(entity.ImageBytes, entity.ImageSlug, "Books");
+                result.Value.ImageUrl = _uploadService.UploadImageAsync(entity.ImageBytes, entity.ImageSlug, "Books").GetAwaiter().GetResult();
 
                 result.Value.ImageBytes = null;
 
@@ -212,6 +213,7 @@ namespace ShareBook.Service
 
         public override Result<Book> Update(Book entity)
         {
+            // TODO: Migrate to Async and remove ".GetAwaiter().GetResult()" and ".Wait()"
             Result<Book> result = Validate(entity, x =>
                 x.Title,
                 x => x.Author,
@@ -234,7 +236,7 @@ namespace ShareBook.Service
             if (!string.IsNullOrEmpty(entity.ImageName) && entity.ImageBytes.Length > 0)
             {
                 entity.ImageSlug = ImageHelper.FormatImageName(entity.ImageName, savedBook.Slug);
-                _uploadService.UploadImage(entity.ImageBytes, savedBook.ImageSlug, "Books");
+                _uploadService.UploadImageAsync(entity.ImageBytes, savedBook.ImageSlug, "Books").GetAwaiter().GetResult();
             }
 
             //preparar o book para atualização

--- a/ShareBook/ShareBook.Service/ContactUs/ContactUsEmailService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/ContactUsEmailService.cs
@@ -6,9 +6,9 @@ namespace ShareBook.Service
     public class ContactUsEmailService : IContactUsEmailService
     {
         private const string ContactUsTemplate = "ContactUsTemplate";
-        private const string ContactUsTitle = "Fale Conosco - Sharebook";
+        public const string ContactUsTitle = "Fale Conosco - Sharebook";
         private const string ContactUsNotificationTemplate = "ContactUsNotificationTemplate";
-        private const string ContactUsNotificationTitle = "Fale Conosco - Sharebook";
+        public const string ContactUsNotificationTitle = "Fale Conosco - Sharebook";
 
         private readonly IEmailService _emailService;
 

--- a/ShareBook/ShareBook.Service/ContactUs/ContactUsEmailService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/ContactUsEmailService.cs
@@ -1,5 +1,4 @@
 ﻿using ShareBook.Domain;
-using ShareBook.Service.AwsSqs;
 using System.Threading.Tasks;
 
 namespace ShareBook.Service
@@ -21,18 +20,18 @@ namespace ShareBook.Service
             _emailService = emailService;
             _emailTemplate = emailTemplate;
         }
-        public async Task SendEmailContactUs(ContactUs contactUs)
+        public async Task SendEmailContactUsAsync(ContactUs contactUs)
         {
-            await SendEmailContactUsToAdministrator(contactUs);
+            await SendEmailContactUsToAdministratorAsync(contactUs);
 
-            await SendEmailNotificationToUser(contactUs);
+            await SendEmailNotificationToUserAsync(contactUs);
         }
-        private async Task SendEmailContactUsToAdministrator(ContactUs contactUs)
+        private async Task SendEmailContactUsToAdministratorAsync(ContactUs contactUs)
         {
             var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(ContactUsTemplate, contactUs);
             await _emailService.SendToAdmins(html, ContactUsTitle);
         }
-        private async Task SendEmailNotificationToUser(ContactUs contactUs)
+        private async Task SendEmailNotificationToUserAsync(ContactUs contactUs)
         {
             var html = await _emailTemplate.GenerateHtmlFromTemplateAsync(ContactUsNotificationTemplate, contactUs);
             await _emailService.Send(contactUs.Email, contactUs.Name, html, ContactUsNotificationTitle, copyAdmins: false, highPriority: true);

--- a/ShareBook/ShareBook.Service/ContactUs/ContactUsService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/ContactUsService.cs
@@ -2,24 +2,25 @@
 using ShareBook.Domain;
 using ShareBook.Domain.Common;
 using ShareBook.Service.Recaptcha;
+using System.Threading.Tasks;
 
 namespace ShareBook.Service
 {
     public class ContactUsService : IContactUsService
     {
-        IContactUsEmailService _contactUsEmailService;
-        IValidator<ContactUs> _validator;
-        IRecaptchaService _recaptchaService;
+        readonly IContactUsEmailService _contactUsEmailService;
+        readonly IValidator<ContactUs> _validator;
+        readonly IRecaptchaService _recaptchaService;
         public ContactUsService(IContactUsEmailService contactUsEmailService, IValidator<ContactUs> validator, IRecaptchaService recaptchaService)
         {
             _contactUsEmailService = contactUsEmailService;
             _validator = validator;
             _recaptchaService = recaptchaService;
         }
-        public Result<ContactUs> SendContactUs(ContactUs entity, string recaptchaReactive)
+        public async Task<Result<ContactUs>> SendContactUsAsync(ContactUs contactUs, string recaptchaReactive)
         {
 
-            var result = new Result<ContactUs>(_validator.Validate(entity));
+            var result = new Result<ContactUs>(_validator.Validate(contactUs));
 
             Result resultRecaptcha = _recaptchaService.SimpleValidationRecaptcha(recaptchaReactive);
             if (!resultRecaptcha.Success)
@@ -28,7 +29,7 @@ namespace ShareBook.Service
             if (!result.Success)
                 return result;
 
-            _contactUsEmailService.SendEmailContactUs(entity).Wait();
+            await _contactUsEmailService.SendEmailContactUsAsync(contactUs);
 
             return result;
         }

--- a/ShareBook/ShareBook.Service/ContactUs/IContactUsEmailService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/IContactUsEmailService.cs
@@ -5,6 +5,6 @@ namespace ShareBook.Service
 {
     public interface IContactUsEmailService
     {
-        Task SendEmailContactUs(ContactUs contactUs);
+        Task SendEmailContactUsAsync(ContactUs contactUs);
     }
 }

--- a/ShareBook/ShareBook.Service/ContactUs/IContactUsService.cs
+++ b/ShareBook/ShareBook.Service/ContactUs/IContactUsService.cs
@@ -1,10 +1,11 @@
 ﻿using ShareBook.Domain;
 using ShareBook.Domain.Common;
+using System.Threading.Tasks;
 
 namespace ShareBook.Service
 {
     public interface IContactUsService
     {
-        Result<ContactUs> SendContactUs(ContactUs contactUs, string recaptchaReactive);
+        Task<Result<ContactUs>> SendContactUsAsync(ContactUs contactUs, string recaptchaReactive);
     }
 }

--- a/ShareBook/ShareBook.Service/Meetup/IMeetupService.cs
+++ b/ShareBook/ShareBook.Service/Meetup/IMeetupService.cs
@@ -8,6 +8,6 @@ namespace ShareBook.Service
     public interface IMeetupService : IBaseService<Meetup>
     {
         public Task<IList<string>> FetchMeetupsAsync();
-        IList<Meetup> Search(string criteria);
+        Task<IList<Meetup>> SearchAsync(string criteria);
     }
 }

--- a/ShareBook/ShareBook.Service/Meetup/MeetupService.cs
+++ b/ShareBook/ShareBook.Service/Meetup/MeetupService.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using Flurl;
 using Flurl.Http;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using ShareBook.Domain;
 using ShareBook.Domain.Exceptions;
@@ -210,15 +211,15 @@ namespace ShareBook.Service
 
             var imageName = ImageHelper.FormatImageName(fileName, imageSlug);
 
-            return _uploadService.UploadImage(resizedImageBytes, imageName, "Meetup");
+            return await _uploadService.UploadImageAsync(resizedImageBytes, imageName, "Meetup");
         }
 
-        public IList<Meetup> Search(string criteria)
+        public async Task<IList<Meetup>> SearchAsync(string criteria)
         {
-            return _repository.Get()
-                .Where(m => m.Active && ( m.Title.ToUpper().Contains(criteria.ToUpper()) || m.Description.ToUpper().Contains(criteria.ToUpper())))
+            return await _repository.Get()
+                .Where(m => m.Active && ( m.Title.Contains(criteria, StringComparison.InvariantCultureIgnoreCase) || m.Description.Contains(criteria, StringComparison.InvariantCultureIgnoreCase)))
                 .OrderByDescending(m => m.CreationDate)
-                .ToList();
+                .ToListAsync();
         }
     }
 }

--- a/ShareBook/ShareBook.Service/Recaptcha/RecaptchaService.cs
+++ b/ShareBook/ShareBook.Service/Recaptcha/RecaptchaService.cs
@@ -5,10 +5,10 @@ namespace ShareBook.Service.Recaptcha
     public class RecaptchaService : IRecaptchaService
     {
         // TODO: Fazer a validação real do "RecaptchaReactive" (https://developers.google.com/recaptcha/docs/verify)
-        public Result SimpleValidationRecaptcha(string recaptchaReactive)
+        public Result SimpleValidationRecaptcha(string recaptcha)
         {
             Result result = new Result();
-            if (string.IsNullOrWhiteSpace(recaptchaReactive) || recaptchaReactive.Length <= 100)
+            if (string.IsNullOrWhiteSpace(recaptcha) || recaptcha.Length <= 100)
                 result.Messages.Add("RecaptchaReactive está inválido!");
 
             return result;

--- a/ShareBook/ShareBook.Service/Upload/IUploadService.cs
+++ b/ShareBook/ShareBook.Service/Upload/IUploadService.cs
@@ -1,9 +1,11 @@
-﻿namespace ShareBook.Service.Upload
+﻿using System.Threading.Tasks;
+
+namespace ShareBook.Service.Upload
 {
     public interface IUploadService
     {
-        string UploadImage(byte[] imageBytes, string imageName, string lastDirectory);
-        string UploadPdf(byte[] imageBytes, string imageName, string lastDirectory);
+        Task<string> UploadImageAsync(byte[] imageBytes, string imageName, string lastDirectory);
+        Task<string> UploadPdfAsync(byte[] imageBytes, string imageName, string lastDirectory);
         string GetImageUrl(string imageName, string lastDirectory);
     }
 }

--- a/ShareBook/ShareBook.Service/Upload/UploadService.cs
+++ b/ShareBook/ShareBook.Service/Upload/UploadService.cs
@@ -3,7 +3,7 @@ using ShareBook.Helper.Image;
 using ShareBook.Service.Server;
 using System;
 using System.IO;
-
+using System.Threading.Tasks;
 
 namespace ShareBook.Service.Upload
 {
@@ -25,7 +25,7 @@ namespace ShareBook.Service.Upload
         }
 
 
-        public string UploadImage(byte[] imageBytes, string imageName, string lastDirectory)
+        public async Task<string> UploadImageAsync(byte[] imageBytes, string imageName, string lastDirectory)
         {
             var dinamicDirectory = Path.Combine(_imageSettings.ImagePath, lastDirectory);
 
@@ -39,29 +39,29 @@ namespace ShareBook.Service.Upload
                 imageName = Path.GetFileNameWithoutExtension(testPath) + DateTimeOffset.Now.ToUnixTimeSeconds() + extension;
             }
 
-            UploadFile(imageBytes, imageName, dinamicDirectory);
+            await UploadFileAsync(imageBytes, imageName, dinamicDirectory);
 
             return GetImageUrl(imageName, lastDirectory);
         }
      
-        public string UploadPdf(byte[] imageBytes, string imageName, string lastDirectory)
+        public async Task<string> UploadPdfAsync(byte[] imageBytes, string imageName, string lastDirectory)
         {
             var dinamicDirectory = Path.Combine(_imageSettings.EBookPdfPath, lastDirectory);
 
-            UploadFile(imageBytes, imageName, dinamicDirectory);
+            await UploadFileAsync(imageBytes, imageName, dinamicDirectory);
 
             return Path.Combine(lastDirectory, dinamicDirectory.Replace("wwwroot", ""), imageName);
 
         }
 
-        private static void UploadFile(byte[] imageBytes, string imageName, string dinamicDirectory)
+        private static async Task UploadFileAsync(byte[] imageBytes, string imageName, string dinamicDirectory)
         {
             var directoryBase = AppDomain.CurrentDomain.BaseDirectory + dinamicDirectory;
             if (!Directory.Exists(directoryBase))
                 Directory.CreateDirectory(directoryBase);
 
             var imageCompletePath = Path.Combine(directoryBase, imageName);
-            File.WriteAllBytes(imageCompletePath, imageBytes);
+            await File.WriteAllBytesAsync(imageCompletePath, imageBytes);
         }
     }
 }

--- a/ShareBook/ShareBook.Test.Unit/Jobs/MeetupSearchTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Jobs/MeetupSearchTests.cs
@@ -1,0 +1,28 @@
+﻿using Moq;
+using Sharebook.Jobs;
+using ShareBook.Service;
+using System.Threading.Tasks;
+using Xunit;
+using ShareBook.Repository;
+using Microsoft.Extensions.Configuration;
+using ShareBook.Domain.Enums;
+
+namespace ShareBook.Test.Unit.Jobs
+{
+    public class MeetupSearchTests
+    {
+        private readonly Mock<IJobHistoryRepository> _mockJobHistoryRepository = new();
+        private readonly Mock<IMeetupService> _mockMeetupService = new();
+        private readonly Mock<IConfiguration> _mockConfiguration = new();
+
+        [Fact]
+        public async Task MeetupSettingsDisabled_ShouldReturn_MeetupDisabled()
+        {
+            _mockConfiguration.SetupGet(s => s[It.IsAny<string>()]).Returns("false");
+            MeetupSearch job = new MeetupSearch(_mockJobHistoryRepository.Object, _mockMeetupService.Object, _mockConfiguration.Object);
+
+            JobResult result = await job.ExecuteAsync();
+            Assert.Equal(JobResult.MeetupDisabled, result);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Test.Unit/Jobs/MeetupSearchTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Jobs/MeetupSearchTests.cs
@@ -6,6 +6,8 @@ using Xunit;
 using ShareBook.Repository;
 using Microsoft.Extensions.Configuration;
 using ShareBook.Domain.Enums;
+using System.Collections.Generic;
+using ShareBook.Domain;
 
 namespace ShareBook.Test.Unit.Jobs
 {
@@ -23,6 +25,20 @@ namespace ShareBook.Test.Unit.Jobs
 
             JobResult result = await job.ExecuteAsync();
             Assert.Equal(JobResult.MeetupDisabled, result);
+        }
+
+        [Fact]
+        public async Task MeetupSettingsEnabled_ShouldReturn_MeetupsCorrectly()
+        {
+            List<string> mockedMeetups = new List<string> { "Meetup Mock 1", "Meetup Mock 2" };
+            _mockConfiguration.SetupGet(s => s[It.IsAny<string>()]).Returns("true");
+            _mockMeetupService.Setup(s => s.FetchMeetupsAsync()).ReturnsAsync(() => mockedMeetups);
+            MeetupSearch job = new MeetupSearch(_mockJobHistoryRepository.Object, _mockMeetupService.Object, _mockConfiguration.Object);
+
+            JobHistory result = await job.WorkAsync();
+            Assert.Equal("MeetupSearch", result.JobName);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(string.Join("\n", mockedMeetups), result.Details);
         }
     }
 }

--- a/ShareBook/ShareBook.Test.Unit/Jobs/MeetupSearchTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Jobs/MeetupSearchTests.cs
@@ -25,6 +25,8 @@ namespace ShareBook.Test.Unit.Jobs
 
             JobResult result = await job.ExecuteAsync();
             Assert.Equal(JobResult.MeetupDisabled, result);
+            _mockMeetupService.VerifyNoOtherCalls();
+            _mockJobHistoryRepository.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -39,6 +41,9 @@ namespace ShareBook.Test.Unit.Jobs
             Assert.Equal("MeetupSearch", result.JobName);
             Assert.True(result.IsSuccess);
             Assert.Equal(string.Join("\n", mockedMeetups), result.Details);
+            _mockMeetupService.Verify(c => c.FetchMeetupsAsync(), Times.Once);
+            _mockMeetupService.VerifyNoOtherCalls();
+            _mockJobHistoryRepository.VerifyNoOtherCalls();
         }
     }
 }

--- a/ShareBook/ShareBook.Test.Unit/Services/BookServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/BookServiceTests.cs
@@ -47,7 +47,7 @@ namespace ShareBook.Test.Unit.Services
             {
                 return BookMock.GetLordTheRings();
             });
-            uploadServiceMock.Setup(service => service.UploadImage(null, null, null));
+            uploadServiceMock.Setup(service => service.UploadImageAsync(null, null, null));
             bookServiceMock.Setup(service => service.Insert(It.IsAny<Book>())).Verifiable();
         }
 

--- a/ShareBook/ShareBook.Test.Unit/Services/ContactUsEmailServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/ContactUsEmailServiceTests.cs
@@ -1,0 +1,43 @@
+﻿using Moq;
+using ShareBook.Domain;
+using ShareBook.Service;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace ShareBook.Test.Unit.Services
+{
+    public class ContactUsEmailServiceTests
+    {
+        private readonly Mock<IEmailService> _mockEmailService = new();
+        private readonly Mock<IEmailTemplate> _mockEmailTemplate = new();
+        private const string HtmlMock = "<html>Example</html>";
+
+        public ContactUsEmailServiceTests()
+        {
+            _mockEmailService.Setup(t => t.SendToAdmins(It.IsAny<string>(), It.IsAny<string>()));
+            _mockEmailService.Setup(t => t.Send(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()));
+            _mockEmailService.Setup(t => t.Send(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+            _mockEmailTemplate.Setup(t => t.GenerateHtmlFromTemplateAsync(It.IsAny<string>(), It.IsAny<object>())).ReturnsAsync(HtmlMock);
+        }
+
+        [Fact]
+        public async Task SendEmailContactToTheUserAndToAdministrators()
+        {
+            ContactUs contactUs = new ContactUs
+            {
+                Email = "joazinho.souza@example.com",
+                Message = "Test message test, Test message test, Test message test",
+                Name = "Joãozinho",
+                Phone = "44 9 8877-6655"
+            };
+            ContactUsEmailService service = new ContactUsEmailService(_mockEmailService.Object, _mockEmailTemplate.Object);
+            await service.SendEmailContactUsAsync(contactUs);
+            
+            _mockEmailService.Verify(s => s.SendToAdmins(HtmlMock, ContactUsEmailService.ContactUsTitle), Times.Once);
+            _mockEmailService.Verify(s => s.Send(contactUs.Email, contactUs.Name, HtmlMock, ContactUsEmailService.ContactUsNotificationTitle, false, true), Times.Once);
+            _mockEmailService.VerifyNoOtherCalls();
+            _mockEmailTemplate.Verify(s => s.GenerateHtmlFromTemplateAsync(It.IsAny<string>(), It.IsAny<object>()), Times.Exactly(2));
+            _mockEmailTemplate.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/ShareBook/ShareBook.Test.Unit/Services/ContactUsServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/ContactUsServiceTests.cs
@@ -4,6 +4,7 @@ using ShareBook.Domain.Common;
 using ShareBook.Domain.Validators;
 using ShareBook.Service;
 using ShareBook.Service.Recaptcha;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace ShareBook.Test.Unit.Services
@@ -24,10 +25,10 @@ namespace ShareBook.Test.Unit.Services
 
         }
         [Fact]
-        public void Invalid()
+        public async Task Invalid()
         {
             ContactUsService service = new ContactUsService(contactUsEmailServiceMock.Object, new ContactUsValidator(), recaptchaService);
-            Result<ContactUs> result = service.SendContactUs(new ContactUs
+            Result<ContactUs> result = await service.SendContactUsAsync(new ContactUs
             {
                 Email = "joazinho",
                 Message = "Test message test, Test message test, Test message test",
@@ -38,10 +39,10 @@ namespace ShareBook.Test.Unit.Services
         }
 
         [Fact]
-        public void Valid()
+        public async Task Valid()
         {
             ContactUsService service = new ContactUsService(contactUsEmailServiceMock.Object, new ContactUsValidator(), recaptchaService);
-            Result<ContactUs> result = service.SendContactUs(new ContactUs
+            Result<ContactUs> result = await service.SendContactUsAsync(new ContactUs
             {
                 Email = "joazinho.souza@example.com",
                 Message = "Test message test, Test message test, Test message test",
@@ -52,10 +53,10 @@ namespace ShareBook.Test.Unit.Services
         }
 
         [Fact]
-        public void InvalidRecaptcha()
+        public async Task InvalidRecaptcha()
         {
             ContactUsService service = new ContactUsService(contactUsEmailServiceMock.Object, new ContactUsValidator(), recaptchaService);
-            Result<ContactUs> result = service.SendContactUs(new ContactUs
+            Result<ContactUs> result = await service.SendContactUsAsync(new ContactUs
             {
                 Email = "joazinho.souza@example.com",
                 Message = "Test message test, Test message test, Test message test",

--- a/ShareBook/ShareBook.Test.Unit/ShareBook.Test.Unit.csproj
+++ b/ShareBook/ShareBook.Test.Unit/ShareBook.Test.Unit.csproj
@@ -21,10 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ShareBook.Domain\ShareBook.Domain.csproj" />
     <ProjectReference Include="..\ShareBook.Infra.CrossCutting.Identity\ShareBook.Infra.CrossCutting.Identity.csproj" />
+    <ProjectReference Include="..\Sharebook.Jobs\Sharebook.Jobs.csproj" />
     <ProjectReference Include="..\ShareBook.Service\ShareBook.Service.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Jobs\1 - ChooseDateReminderTest.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The changes are made based on [.NET AsyncGuidance](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md).

- Turning endpoint of `ContactUsController` and `MeetupController` as async
- Got rid some warnings
- Adding unit test for `ContactUsEmailService. SendEmailContactUsAsync`
- Adding unit tests for `Jobs.MeetupSearchTests` ([MR 558](https://github.com/SharebookBR/sharebook-backend/pull/558))