### PR TITLE
feat: Adding manual job "Postman collection validations" for dev environment + fix EmailService using ssl config

### DIFF
--- a/.github/workflows/postman-collection.yml
+++ b/.github/workflows/postman-collection.yml
@@ -1,0 +1,17 @@
+name: Postman collection validations
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-postman-collection-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Postman collection - Development environment
+        uses: matt-ball/newman-action@master
+        with:
+          collection: ShareBook API - Tests.postman_collection.json
+          delayRequest: 2000
+          envVar: '[{ "key": "sharebookUrl", "value": "https://dev.sharebook.com.br/" }, { "key": "sharebookEmail", "value": "raffacabofrio@gmail.com" }, { "key": "sharebookPassword", "value": "123456" }]'
+# TODO: Add a job for production environment which must get username and password from github secrets

--- a/ShareBook API - Tests.postman_collection.json
+++ b/ShareBook API - Tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f7913a70-c6f4-4636-86a3-347efa40216f",
+		"_postman_id": "4a0b707e-0039-4e40-8fbe-17d85d626c63",
 		"name": "ShareBook API - Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "29881360"
@@ -583,7 +583,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n\t\"email\": \"raffacabofrio@gmail.com\",\r\n\t\"password\": \"123456\"\r\n}",
+							"raw": "{\r\n\t\"email\": \"{{sharebookEmail}}\",\r\n\t\"password\": \"{{sharebookPassword}}\"\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -891,13 +891,34 @@
 				"type": "text/javascript",
 				"packages": {},
 				"exec": [
+					"\r",
+					"console.log('Setting up...')\r",
+					"\r",
 					"const sharebookUrlName = 'sharebookUrl'\r",
-					"if (pm.globals.has(sharebookUrlName))\r",
-					"    console.log(`Running using ${pm.globals.get(sharebookUrlName)}`)\r",
+					"if (pm.environment.has(sharebookUrlName))\r",
+					"    console.log(`Running with ${sharebookUrlName} ${pm.environment.get(sharebookUrlName)}`)\r",
 					"else {\r",
 					"    const fallbackUrl = 'https://dev.sharebook.com.br/'\r",
-					"    console.log(`The global variable ${sharebookUrlName} isn't found. Using ${fallbackUrl} as default value... `)\r",
-					"    pm.globals.set(sharebookUrlName, fallbackUrl)\r",
+					"    console.log(`The environment variable ${sharebookUrlName} isn't found. Using ${fallbackUrl} as default value... `)\r",
+					"    pm.environment.set(sharebookUrlName, fallbackUrl)\r",
+					"}\r",
+					"\r",
+					"const sharebookEmailName = 'sharebookEmail';\r",
+					"if (pm.environment.has(sharebookEmailName))\r",
+					"    console.log(`Running with ${sharebookEmailName} : ${pm.environment.get(sharebookEmailName)}`)\r",
+					"else {\r",
+					"    const fallBackEmail = 'raffacabofrio@gmail.com'\r",
+					"    console.log(`The environment variable ${sharebookEmailName} isn't found. Using ${fallBackEmail} as default value... `)\r",
+					"    pm.environment.set(sharebookEmailName, fallBackEmail)\r",
+					"}\r",
+					"\r",
+					"const sharebookPasswordName = 'sharebookPassword';\r",
+					"if (pm.environment.has(sharebookPasswordName))\r",
+					"    console.log(`Running with ${sharebookPasswordName} : ${pm.environment.get(sharebookPasswordName)}`)\r",
+					"else {\r",
+					"    const fallBackPassword = '123456'\r",
+					"    console.log(`The environment variable ${sharebookPasswordName} isn't found. Using ${fallBackPassword} as default value... `)\r",
+					"    pm.environment.set(sharebookPasswordName, fallBackPassword)\r",
 					"}"
 				]
 			}

--- a/ShareBook/ShareBook.Service/Email/EmailService.cs
+++ b/ShareBook/ShareBook.Service/Email/EmailService.cs
@@ -157,7 +157,7 @@ public class EmailService : IEmailService
             return log;
         }
 
-        await _imapClient.ConnectAsync(_settings.HostName, _settings.ImapPort, true);
+        await _imapClient.ConnectAsync(_settings.HostName, _settings.ImapPort, _settings.UseSSL);
         await _imapClient.AuthenticateAsync(_settings.Username, _settings.Password);
 
         var bounceFolder = await GetBounceFolderAsync();


### PR DESCRIPTION
With these updates we'll be able to manually trigger/start this job to check/validate if the dev environment is ok using our postman collection which is in the repository.

Note: I let the job as `workflow_dispatch` (to manually start it) because I'm not sure when a new version pushed to `develop` branch will be available at our dev environment (until I know we do the deployment to there outside the github actions)

---

#### EmailService

As we discussed through our WhatsApp group, we need to change the `ImapPort`, but then we need to stablish the connection with `useSsl=false`, which was fixed as `true` in the source code. Now it'll get from `appsettings`.